### PR TITLE
feat: Strengthen calculator SEO pages (#9)

### DIFF
--- a/_includes/faq_section.html
+++ b/_includes/faq_section.html
@@ -1,0 +1,11 @@
+{% if page.faqs %}
+<section class="faq-section">
+  <h2>Frequently Asked Questions</h2>
+  {% for faq in page.faqs %}
+  <div class="faq-item">
+    <h3>{{ faq.question }}</h3>
+    <p>{{ faq.answer }}</p>
+  </div>
+  {% endfor %}
+</section>
+{% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -103,4 +103,24 @@
     }
   </script>
   {% endunless %}
+  {% if page.faqs %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {% for faq in page.faqs %}
+        {
+          "@type": "Question",
+          "name": {{ faq.question | jsonify }},
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": {{ faq.answer | strip_html | jsonify }}
+          }
+        }{% unless forloop.last %},{% endunless %}
+        {% endfor %}
+      ]
+    }
+  </script>
+  {% endif %}
 </head>

--- a/_includes/related_calculators.html
+++ b/_includes/related_calculators.html
@@ -1,0 +1,13 @@
+{% if page.related_calculators %}
+<section class="related-calculators">
+  <h2>Related Calculator Guides</h2>
+  <ul>
+    {% for related_page in page.related_calculators %}
+    <li>
+      <a href="{{ related_page.url | relative_url }}">{{ related_page.title }}</a>
+      <span>{{ related_page.description }}</span>
+    </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}

--- a/_pages/bathroom-remodel-cost-estimator.md
+++ b/_pages/bathroom-remodel-cost-estimator.md
@@ -1,29 +1,65 @@
 ---
 layout: page
 title: Bathroom Remodel Cost Estimator
-seo_title: Bathroom Remodel Cost Estimator | Rehab Estimator
-meta_description: Estimate bathroom remodel costs for demo, tile, fixtures, plumbing, electrical, vanity, paint, photos, and PDF reporting.
+seo_title: Bathroom Remodel Cost Estimator for Rehab Scopes | Rehab Estimator
+meta_description: Estimate bathroom remodel costs for demo, tile, vanity, fixtures, plumbing, electrical, ventilation, paint, trim, and cleanup.
 include_in_header: false
 permalink: /bathroom-remodel-cost-estimator/
+faqs:
+  - question: What should a bathroom remodel estimate include?
+    answer: A bathroom remodel estimate should include demo, waterproofing, tile, tub or shower work, toilet, vanity, fixtures, plumbing, electrical, ventilation, paint, trim, cleanup, and contingency.
+  - question: Why are bathroom remodel costs hard to estimate?
+    answer: Bathrooms are small but trade-heavy. Plumbing, electrical, waterproofing, tile work, hidden water damage, and fixture choices can change the budget quickly.
+  - question: Should small bathroom repairs be estimated separately?
+    answer: Yes. Separating vanity, toilet, fixtures, tile, paint, and plumbing makes it easier to review contractor feedback and avoid treating every bathroom as a full gut remodel.
+related_calculators:
+  - title: Rehab Cost Calculator
+    url: /rehab-cost-calculator/
+    description: Include bathroom tasks in the full interior and general repair budget.
+  - title: Rental Cashflow Calculator
+    url: /rental-cashflow-calculator/
+    description: Check how bathroom repairs affect rent readiness and cash reserves.
+  - title: Kitchen Remodel Cost Estimator
+    url: /kitchen-remodel-cost-estimator/
+    description: Compare another interior remodel scope with materials and trade work.
 ---
 
 <div class="page-hero">
   <p class="eyebrow">Bathroom remodel cost estimator</p>
-  <h1>Estimate bathroom repair costs before the walkthrough details fade.</h1>
-  <p>Rehab Estimator helps you capture bathroom remodel tasks, cost ranges, quantities, and photo notes as part of the full rehab estimate.</p>
+  <h1>Price bathroom remodel work before small trade costs pile up.</h1>
+  <p>Separate tile, fixtures, plumbing, electrical, ventilation, paint, and photo-backed notes inside the full rehab estimate.</p>
 </div>
 
-## Bathroom costs to include
+## Bathroom costs to include in a rehab estimate
 
-Bathroom remodel budgets often move because small rooms contain several trades. Include demo, waterproofing, tile, tub or shower work, vanity, fixtures, plumbing updates, electrical updates, ventilation, paint, trim, and cleanup.
+Bathroom remodel budgets often move because small rooms contain several trades. Include demo, waterproofing, tile, tub or shower work, vanity, fixtures, plumbing updates, electrical updates, ventilation, paint, trim, cleanup, and contingency.
 
-## Why task-level estimates matter
+## Common bathroom line items
+
+| Line item | Estimating note |
+| --- | --- |
+| Demo and disposal | Include hauling, dust control, and fixture removal. |
+| Waterproofing and tile | Separate floor, wall, shower, and backsplash assumptions. |
+| Vanity and fixtures | Track allowance quality and replacement scope. |
+| Plumbing | Note supply, drain, valve, toilet, tub, and shower changes. |
+| Electrical and ventilation | Include fan replacement, GFCI, lighting, and code updates. |
+| Paint and trim | Include finish work after trade and tile work are complete. |
+
+## Why task-level bathroom estimates matter
 
 A single bathroom total is hard to review. Task-level ranges make it easier to compare contractor feedback, separate cosmetic updates from plumbing or tile work, and keep the estimate conservative before purchase or project approval.
+
+## Scope levels to separate
+
+Separate cosmetic refreshes from partial remodels and full gut remodels. A paint-and-fixture refresh should not be priced like tile replacement, and tile replacement should not be priced like moving plumbing. The estimate should show which version of the scope the number supports.
 
 ## Field workflow
 
 Create the report, add bathroom tasks under the interior scope, attach photos, and update the quantities as the scope gets clearer. Export a PDF when the estimate needs to be shared.
+
+{% include related_calculators.html %}
+
+{% include faq_section.html %}
 
 <div class="page-cta">
   <h2>Build a bathroom remodel estimate in Rehab Estimator.</h2>

--- a/_pages/fix-and-flip-calculator.md
+++ b/_pages/fix-and-flip-calculator.md
@@ -1,32 +1,68 @@
 ---
 layout: page
 title: Fix and Flip Calculator
-seo_title: Fix and Flip Calculator | Rehab Estimator
-meta_description: Calculate fix and flip deal numbers, including purchase price, rehab cost, resale value, and profit assumptions.
+seo_title: Fix and Flip Calculator for Rehab Deals | Rehab Estimator
+meta_description: Calculate flip profit with purchase price, rehab budget, ARV, holding costs, selling costs, financing, and contingency.
 include_in_header: false
 permalink: /fix-and-flip-calculator/
+faqs:
+  - question: What numbers should a fix and flip calculator use?
+    answer: A fix and flip calculator should include purchase price, after repair value, rehab cost, closing costs, holding costs, selling costs, financing costs, contingency, and target profit.
+  - question: How should rehab costs be handled in flip math?
+    answer: Rehab costs should come from a scoped estimate, not a flat percentage. Separate confirmed contractor prices from allowances and include a contingency for unknown work.
+  - question: What is a good profit margin for a flip?
+    answer: The required margin depends on risk, timeline, financing, and local resale confidence. Many investors test a conservative case first to make sure a small repair or sale price miss does not erase the deal.
+related_calculators:
+  - title: Rehab Cost Calculator
+    url: /rehab-cost-calculator/
+    description: Build the repair budget that feeds the flip profit calculation.
+  - title: Kitchen Remodel Cost Estimator
+    url: /kitchen-remodel-cost-estimator/
+    description: Price one of the biggest resale-sensitive interior scopes before setting ARV assumptions.
+  - title: Bathroom Remodel Cost Estimator
+    url: /bathroom-remodel-cost-estimator/
+    description: Estimate bathroom repair work that can change both rehab cost and buyer expectations.
 ---
 
 <div class="page-hero">
   <p class="eyebrow">Fix and flip calculator</p>
-  <h1>Check whether a flip still works after the rehab budget changes.</h1>
-  <p>Rehab Estimator pairs rehab scope planning with deal math, so your repair estimate can feed the investment decision.</p>
+  <h1>Pressure-test a flip with repair, resale, holding, and selling costs.</h1>
+  <p>Connect the rehab estimate to the deal model so a stronger resale price does not hide a weak repair budget.</p>
 </div>
 
-## What to calculate before buying
+## What to calculate before making an offer
 
-A useful fix and flip estimate needs more than a repair total. Track purchase price, resale value, financing or cash assumptions, closing costs, holding costs, selling costs, and the rehab budget. When any one of those inputs changes, the deal result should be easy to recalculate.
+A flip needs enough room for acquisition costs, repairs, time, selling friction, and profit. The repair number is usually the most visible risk, but holding time and resale assumptions can move just as fast. Run the deal with conservative repair and resale numbers before deciding whether the offer still works.
 
-## Where Rehab Estimator helps
+## Core inputs for flip analysis
+
+| Input | What to check |
+| --- | --- |
+| Purchase price | Include assignment fees, closing costs, and any seller credits. |
+| After repair value | Use realistic comps, not the best sale in the neighborhood. |
+| Rehab budget | Tie the number to scoped tasks, photos, and cost ranges. |
+| Holding costs | Include loan payments, utilities, taxes, insurance, and timeline risk. |
+| Selling costs | Include agent commissions, closing costs, staging, concessions, and cleanup. |
+| Contingency | Reserve for scope misses, price changes, and delays. |
+
+## How repair scope changes the deal
+
+A flip can look profitable until the rehab scope moves from cosmetic to systems work. Roof, HVAC, plumbing, electrical, foundation, and layout changes should be modeled separately because they can affect both budget and timeline. If the high side of the repair estimate kills the profit, the offer needs to change.
+
+## Where Rehab Estimator fits
 
 - Build the rehab estimate from the same scope of work you reviewed at the property.
 - Keep a low-to-high repair range instead of a single optimistic number.
 - Compare deal assumptions in the calculator before sending the report.
 - Export a PDF estimate when you need a cleaner handoff.
 
-## Practical workflow
+## Practical workflow for a flip
 
 Create the property report first, add the major repair categories, then use the fix and flip calculator to test the deal against conservative repair and resale assumptions. Update the report after contractor pricing comes in.
+
+{% include related_calculators.html %}
+
+{% include faq_section.html %}
 
 <div class="page-cta">
   <h2>Run the rehab budget and flip math together.</h2>

--- a/_pages/kitchen-remodel-cost-estimator.md
+++ b/_pages/kitchen-remodel-cost-estimator.md
@@ -1,32 +1,65 @@
 ---
 layout: page
 title: Kitchen Remodel Cost Estimator
-seo_title: Kitchen Remodel Cost Estimator | Rehab Estimator
-meta_description: Estimate kitchen remodel costs for cabinets, countertops, flooring, plumbing, electrical, paint, and photos before exporting a PDF report.
+seo_title: Kitchen Remodel Cost Estimator for Rehab Budgets | Rehab Estimator
+meta_description: Estimate kitchen remodel costs for cabinets, counters, flooring, appliances, plumbing, electrical, paint, demo, and cleanup.
 include_in_header: false
 permalink: /kitchen-remodel-cost-estimator/
+faqs:
+  - question: What should a kitchen remodel cost estimate include?
+    answer: A kitchen remodel estimate should include demo, cabinets, countertops, backsplash, flooring, appliances, plumbing, electrical, lighting, paint, trim, permits, cleanup, and contingency.
+  - question: Why do kitchen remodel budgets change so much?
+    answer: Kitchen budgets move when layout, cabinet quality, countertop material, appliance packages, electrical work, plumbing changes, or hidden damage changes after the first walkthrough.
+  - question: Should appliances be included in the kitchen estimate?
+    answer: Yes, if the investor or owner is responsible for them. Keep appliance allowances separate so they can be adjusted without changing the labor scope.
+related_calculators:
+  - title: Rehab Cost Calculator
+    url: /rehab-cost-calculator/
+    description: Roll kitchen line items into the full property repair budget.
+  - title: Fix and Flip Calculator
+    url: /fix-and-flip-calculator/
+    description: Test whether kitchen upgrade choices still leave enough flip profit.
+  - title: Bathroom Remodel Cost Estimator
+    url: /bathroom-remodel-cost-estimator/
+    description: Estimate another high-impact interior scope with trade-heavy costs.
 ---
 
 <div class="page-hero">
   <p class="eyebrow">Kitchen remodel cost estimator</p>
-  <h1>Build a kitchen renovation budget with task-level cost ranges.</h1>
-  <p>Rehab Estimator helps you price kitchen work as part of a full property rehab estimate, then keep the scope, quantities, photos, and PDF report together.</p>
+  <h1>Estimate kitchen remodel costs by line item, not by guesswork.</h1>
+  <p>Price cabinets, counters, flooring, fixtures, trades, photos, and allowances as part of the full rehab budget.</p>
 </div>
 
-## Kitchen costs to include
+## Kitchen costs to include in the estimate
 
-A useful kitchen remodel estimate should separate cabinets, countertops, flooring, backsplash, paint, plumbing fixtures, electrical updates, appliance allowances, demo, and cleanup. Keeping these as task-level items makes the total easier to review when contractor bids change.
+A kitchen budget is easier to defend when the work is separated into line items. Cabinets, countertops, flooring, backsplash, fixtures, electrical, plumbing, lighting, appliances, painting, demo, and cleanup can each move for different reasons. A single kitchen total hides those changes.
 
-## How Rehab Estimator helps
+## Common line items
 
-- Add kitchen work under interior scope categories.
-- Track low-to-high ranges instead of one fixed guess.
-- Attach photos from the walkthrough to support the estimate.
-- Include the kitchen scope in a PDF report for investors, contractors, or clients.
+| Line item | Estimating note |
+| --- | --- |
+| Cabinets | Separate paint, refacing, stock replacement, and custom work. |
+| Countertops | Track material choice and linear footage assumptions. |
+| Flooring | Include demo, subfloor repair, transitions, and install labor. |
+| Plumbing | Note sink, disposal, dishwasher, supply, and drain changes. |
+| Electrical | Include GFCI, lighting, outlets, panel limits, and code needs. |
+| Appliances | Keep allowances separate from confirmed purchase prices. |
+
+## Where kitchen estimates usually miss
+
+Kitchen remodel estimates often miss hidden water damage, subfloor work, electrical upgrades, cabinet layout changes, ventilation, appliance delivery, and finish details. Add a note when a number is an allowance so it does not look like a confirmed bid.
+
+## How Rehab Estimator helps during the walkthrough
+
+Add kitchen work under interior scope categories, attach photos to the tasks, and track low-to-high ranges until contractor pricing tightens the budget. The kitchen scope can stay inside the full property report instead of living in a separate spreadsheet.
 
 ## Field workflow
 
 Walk the kitchen, capture photos, add the major task groups, and adjust quantities after measuring or receiving bids. The kitchen estimate can stay inside the larger rehab report instead of living in a separate spreadsheet.
+
+{% include related_calculators.html %}
+
+{% include faq_section.html %}
 
 <div class="page-cta">
   <h2>Estimate kitchen remodel costs in the app.</h2>

--- a/_pages/rehab-cost-calculator.md
+++ b/_pages/rehab-cost-calculator.md
@@ -1,31 +1,66 @@
 ---
 layout: page
 title: Rehab Cost Calculator
-seo_title: Rehab Cost Calculator | Rehab Estimator
-meta_description: Estimate rehab costs by scope category, add photos, and turn the budget into a PDF report with Rehab Estimator.
+seo_title: Rehab Cost Calculator for Property Repairs | Rehab Estimator
+meta_description: Build a rehab cost estimate by room, scope category, quantity, and cost range before turning it into a PDF report.
 include_in_header: false
 permalink: /rehab-cost-calculator/
+faqs:
+  - question: What should a rehab cost calculator include?
+    answer: A rehab cost calculator should include interior, exterior, and project-level work, plus quantities, low-to-high cost ranges, photos, and notes that explain why each repair is in the estimate.
+  - question: Is a rehab estimate the same as a contractor bid?
+    answer: No. A rehab estimate is an early planning range for offers, underwriting, and scope review. A contractor bid should come later when trades inspect the property and price the exact materials and labor.
+  - question: Why use cost ranges instead of one repair number?
+    answer: Ranges keep the estimate honest when measurements, hidden damage, labor pricing, or material choices can still change. The high number is useful for conservative offer and reserve planning.
+related_calculators:
+  - title: Fix and Flip Calculator
+    url: /fix-and-flip-calculator/
+    description: Use the repair estimate inside purchase, resale, holding cost, and profit assumptions.
+  - title: Rental Cashflow Calculator
+    url: /rental-cashflow-calculator/
+    description: Check how repairs affect rent readiness, reserves, debt needs, and cashflow.
+  - title: Kitchen Remodel Cost Estimator
+    url: /kitchen-remodel-cost-estimator/
+    description: Break kitchen work into cabinets, counters, flooring, electrical, plumbing, and finish items.
 ---
 
 <div class="page-hero">
   <p class="eyebrow">Rehab cost calculator</p>
-  <h1>Estimate renovation costs by scope, task, and property details.</h1>
-  <p>Rehab Estimator helps you build a rehab budget from interior, exterior, and general work categories, then keep the numbers attached to the report you share.</p>
+  <h1>Build a room-by-room rehab cost estimate before you make the offer.</h1>
+  <p>Use scope categories, quantities, photos, and low-to-high cost ranges to turn a walkthrough into a repair budget that can be reviewed and shared.</p>
 </div>
 
-## What the calculator is for
+## What to capture during the walkthrough
 
-Use Rehab Estimator when you need a fast first-pass budget during a walkthrough, a cleaner estimate after contractor feedback, or a report that can be shared with a partner. The app keeps task ranges, quantities, property details, and photo notes together.
+A useful rehab estimate starts with the property condition, not with a single dollar amount. Walk the house by area, separate visible repairs from assumptions, and note the trade, quantity, unit cost, and confidence level for each task.
 
-## Common rehab cost categories
+Keep photos next to the line items they support. A note like "replace lower kitchen cabinets due to water damage" is easier to review when the photo, quantity, and cost range stay attached to the same task.
+
+## Common rehab cost categories to price
 
 - Interior work: demo, framing, sheetrock, flooring, painting, cabinets, countertops, plumbing, electrical, and HVAC.
 - Exterior work: roof, siding, gutters, garage, concrete, landscaping, septic tank, foundation, and exterior paint.
 - General work: permits, termite treatment, mold remediation, and other project-level items.
+- Contingency: unknown items that are likely to appear after demo, inspection, or contractor review.
 
-## How to use the numbers
+## How to build a defensible estimate
 
-Start with a scope category, add tasks that match the property, then adjust quantities and cost ranges when you have better local pricing. The report total gives a low-to-high estimate, which is useful before you commit to a final contractor bid.
+Start with obvious scope items, then add ranges where the final number depends on measurements or trade pricing. Use the low number for a clean version of the work and the high number for the realistic downside. Keep allowances separate from confirmed contractor prices so the report shows which parts of the budget still need proof.
+
+| Estimate input | Why it matters |
+| --- | --- |
+| Scope category | Keeps interior, exterior, and general work from blending together. |
+| Quantity | Prevents one-room assumptions from being applied to the whole property. |
+| Low and high cost | Shows the spread between optimistic and conservative repair math. |
+| Photos and notes | Explains the reason behind each line item when the report is shared. |
+
+## When to update the estimate
+
+Update the rehab cost estimate after measuring rooms, receiving contractor feedback, finding hidden damage, or changing the planned finish level. The estimate should move from a quick walkthrough range toward a tighter scope-backed budget as the deal or project gets closer to approval.
+
+{% include related_calculators.html %}
+
+{% include faq_section.html %}
 
 <div class="page-cta">
   <h2>Build a rehab estimate in the app.</h2>

--- a/_pages/rental-cashflow-calculator.md
+++ b/_pages/rental-cashflow-calculator.md
@@ -1,29 +1,65 @@
 ---
 layout: page
 title: Rental Cashflow Calculator
-seo_title: Rental Cashflow Calculator | Rehab Estimator
-meta_description: Estimate rental cashflow with rent, payment, vacancy, taxes, insurance, maintenance, and rehab assumptions.
+seo_title: Rental Cashflow Calculator with Rehab Costs | Rehab Estimator
+meta_description: Estimate rental cashflow with rent, debt service, vacancy, taxes, insurance, maintenance, management, and repair costs.
 include_in_header: false
 permalink: /rental-cashflow-calculator/
+faqs:
+  - question: What expenses should a rental cashflow calculator include?
+    answer: A rental cashflow calculator should include rent, mortgage payment, taxes, insurance, vacancy, maintenance, property management, utilities paid by the owner, capital reserves, and repair costs needed before rent starts.
+  - question: Should rehab costs be included in monthly cashflow?
+    answer: Upfront rehab costs usually belong in the acquisition and cash-on-cash return analysis. Ongoing maintenance and reserves should be included in monthly cashflow.
+  - question: Why can a rental with strong rent still be a weak deal?
+    answer: High repairs, vacancy, debt service, insurance, taxes, management, or delayed rent start can reduce the actual cashflow even when the gross rent looks good.
+related_calculators:
+  - title: Rehab Cost Calculator
+    url: /rehab-cost-calculator/
+    description: Estimate repairs before trusting the rent-ready timeline.
+  - title: Fix and Flip Calculator
+    url: /fix-and-flip-calculator/
+    description: Compare rental hold math against a resale strategy for the same property.
+  - title: Bathroom Remodel Cost Estimator
+    url: /bathroom-remodel-cost-estimator/
+    description: Price bathroom repairs that affect rent readiness and maintenance risk.
 ---
 
 <div class="page-hero">
   <p class="eyebrow">Rental cashflow calculator</p>
-  <h1>Estimate whether a rental still cashflows after repairs.</h1>
-  <p>Rehab Estimator lets you keep the renovation estimate close to the rental analysis, so repair costs are part of the cashflow decision from the start.</p>
+  <h1>See whether a rental still cashflows after the repair budget.</h1>
+  <p>Model the income, operating expenses, debt, vacancy, reserves, and rehab assumptions that decide whether a property is actually rent-ready.</p>
 </div>
 
-## Inputs worth checking
+## Inputs worth checking before buying
 
-A rental analysis should include monthly rent, loan or cash purchase assumptions, vacancy, property tax, insurance, maintenance, management fees, and the rehab cost needed before the property can be rented.
+A rental can look strong when rent is viewed alone. The cashflow test should include recurring expenses, the cost to make the unit rentable, and the time before income starts. Repairs affect cash invested, reserves, debt needs, and the first month a tenant can move in.
 
-## Why pair it with a rehab estimate
+## Rental cashflow inputs to separate
+
+| Input | How to use it |
+| --- | --- |
+| Gross monthly rent | Base it on current local listings and leased comps. |
+| Vacancy | Reduce income for expected turnover and lease-up time. |
+| Debt service | Include principal and interest if the property is financed. |
+| Taxes and insurance | Use property-specific numbers when available. |
+| Maintenance and reserves | Plan for recurring repairs and future capital items. |
+| Upfront rehab | Track the cash needed before the property can produce rent. |
+
+## Why repair costs belong near the cashflow math
 
 Repair costs affect cash-on-cash return, reserves, debt needs, and the time before rent starts. Keeping the rehab budget and rental calculator in one app reduces the chance that a promising rent number hides a weak repair budget.
+
+## What to do when cashflow is thin
+
+If the deal only works with low repairs, full rent, and no delays, test the downside case before moving forward. Increase vacancy, raise the repair budget, and include maintenance reserves. If the property still works in the conservative case, the deal is easier to defend.
 
 ## Field workflow
 
 Capture the property details, add repair tasks by scope, attach photo notes, and then run the rental cashflow calculator. Update the estimate as bids come in, then export a PDF for review.
+
+{% include related_calculators.html %}
+
+{% include faq_section.html %}
 
 <div class="page-cta">
   <h2>Estimate the repairs before trusting the rent number.</h2>

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -567,6 +567,65 @@ main {
   margin-top: 22px;
 }
 
+.related-calculators,
+.faq-section {
+  margin-top: 34px;
+  padding-top: 28px;
+  border-top: 1px solid $soft-border-color;
+}
+
+.related-calculators h2,
+.faq-section h2 {
+  color: $primary-text-color;
+  font-size: 2.6rem;
+  line-height: 1.2;
+}
+
+.related-calculators ul {
+  display: grid;
+  gap: 14px;
+  margin-top: 18px;
+  padding-left: 0;
+  list-style: none;
+}
+
+.related-calculators li {
+  padding: 16px 0;
+  border-bottom: 1px solid rgba($soft-border-color, 0.72);
+}
+
+.related-calculators li:last-child {
+  border-bottom: 0;
+}
+
+.related-calculators a {
+  display: inline-block;
+  font-weight: 750;
+}
+
+.related-calculators span {
+  display: block;
+  margin-top: 6px;
+  color: $muted-text-color;
+  font-size: 1.55rem;
+  line-height: 1.45;
+}
+
+.faq-item {
+  margin-top: 20px;
+}
+
+.faq-item h3 {
+  color: $primary-text-color;
+  font-size: 2rem;
+  line-height: 1.25;
+}
+
+.faq-item p {
+  margin-top: 8px;
+  color: $muted-text-color;
+}
+
 .hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary
- Expands the five calculator and estimator pages with search-intent sections, comparison tables, workflow guidance, and unique H1/title copy.
- Adds visible FAQ sections backed by page-specific FAQPage JSON-LD.
- Adds related calculator links so each target page links to at least two related pages.
- Adds lightweight styles for FAQ and related-link sections using the existing page layout.

## Validation
- `bundle exec jekyll build --quiet`
- `ruby -rjson -e ...` parsed generated JSON-LD for all five target pages and confirmed each page has 3 FAQ entries and related links.
- `git diff --check`

Validated generated pages:
- `/rehab-cost-calculator/`: 3 FAQs, related links, JSON-LD valid
- `/fix-and-flip-calculator/`: 3 FAQs, related links, JSON-LD valid
- `/rental-cashflow-calculator/`: 3 FAQs, related links, JSON-LD valid
- `/kitchen-remodel-cost-estimator/`: 3 FAQs, related links, JSON-LD valid
- `/bathroom-remodel-cost-estimator/`: 3 FAQs, related links, JSON-LD valid

## Search Console re-inspection after deploy
Request inspection for these canonical URLs after this PR is deployed:
- `https://app.rehabestimator.app/rehab-cost-calculator/`
- `https://app.rehabestimator.app/fix-and-flip-calculator/`
- `https://app.rehabestimator.app/rental-cashflow-calculator/`
- `https://app.rehabestimator.app/kitchen-remodel-cost-estimator/`
- `https://app.rehabestimator.app/bathroom-remodel-cost-estimator/`

## Notes
- I did not start a local dev server. Mobile behavior was checked through code and generated markup only.

Closes #9