### PR TITLE
feat: Add interactive calculator tools (#4)

### DIFF
--- a/_includes/calculator_tools/fix_flip.html
+++ b/_includes/calculator_tools/fix_flip.html
@@ -1,0 +1,72 @@
+<section class="calculator-tool" data-calculator="fix-flip">
+  <div class="calculator-tool__header">
+    <h2>Fix and Flip Calculator</h2>
+    <p>Estimate maximum purchase price and projected profit from ARV, repairs, selling costs, and hold time.</p>
+  </div>
+
+  <form class="calculator-form">
+    <label>
+      <span>After repair value</span>
+      <input type="number" min="1" step="5000" value="350000" data-input="arv" inputmode="decimal">
+    </label>
+    <label>
+      <span>Purchase price</span>
+      <input type="number" min="0" step="5000" value="230000" data-input="purchasePrice" inputmode="decimal">
+    </label>
+    <label>
+      <span>Desired profit</span>
+      <input type="number" min="0" step="1000" value="40000" data-input="desiredProfit" inputmode="decimal">
+    </label>
+    <label>
+      <span>Repair cost</span>
+      <input type="number" min="0" step="1000" value="45000" data-input="repairCost" inputmode="decimal">
+    </label>
+    <label>
+      <span>Purchase costs</span>
+      <input type="number" min="0" step="500" value="6000" data-input="purchaseCost" inputmode="decimal">
+    </label>
+    <label>
+      <span>Selling costs</span>
+      <input type="number" min="0" step="500" value="5000" data-input="saleCost" inputmode="decimal">
+    </label>
+    <label>
+      <span>Holding cost per month</span>
+      <input type="number" min="0" step="100" value="2200" data-input="monthlyHoldingCost" inputmode="decimal">
+    </label>
+    <label>
+      <span>Holding months</span>
+      <input type="number" min="0" step="1" value="5" data-input="holdingMonths" inputmode="decimal">
+    </label>
+    <label>
+      <span>Agent commission</span>
+      <input type="number" min="0" max="12" step="0.25" value="6" data-input="commissionRate" inputmode="decimal">
+    </label>
+  </form>
+
+  <p class="calculator-error" data-error aria-live="polite"></p>
+
+  <div class="calculator-results" aria-live="polite">
+    <div>
+      <span>Maximum purchase price</span>
+      <strong data-output="maxPurchasePrice">$0</strong>
+    </div>
+    <div>
+      <span>Projected profit</span>
+      <strong data-output="projectedProfit">$0</strong>
+    </div>
+    <div>
+      <span>Profit margin</span>
+      <strong data-output="profitMargin">0%</strong>
+    </div>
+  </div>
+
+  <div class="calculator-breakdown">
+    <h3>Cost summary</h3>
+    <dl data-output="breakdown"></dl>
+  </div>
+
+  <div class="calculator-tool__cta">
+    <p>Save the deal assumptions with the repair scope, photos, and PDF report in Rehab Estimator.</p>
+    {% include download_cta.html %}
+  </div>
+</section>

--- a/_includes/calculator_tools/rehab_cost.html
+++ b/_includes/calculator_tools/rehab_cost.html
@@ -1,0 +1,52 @@
+<section class="calculator-tool" data-calculator="rehab-cost">
+  <div class="calculator-tool__header">
+    <h2>Rehab Cost Calculator</h2>
+    <p>Estimate a low and high repair range from square footage, rehab intensity, and contingency.</p>
+  </div>
+
+  <form class="calculator-form">
+    <label>
+      <span>Square footage</span>
+      <input type="number" min="1" step="50" value="1500" data-input="squareFeet" inputmode="decimal">
+    </label>
+    <label>
+      <span>Rehab intensity</span>
+      <select data-input="intensity">
+        <option value="light">Light cosmetic</option>
+        <option value="medium" selected>Medium rehab</option>
+        <option value="heavy">Heavy rehab</option>
+      </select>
+    </label>
+    <label>
+      <span>Contingency</span>
+      <input type="number" min="0" max="40" step="1" value="10" data-input="contingencyRate" inputmode="decimal">
+    </label>
+  </form>
+
+  <p class="calculator-error" data-error aria-live="polite"></p>
+
+  <div class="calculator-results" aria-live="polite">
+    <div>
+      <span>Low estimate</span>
+      <strong data-output="lowTotal">$0</strong>
+    </div>
+    <div>
+      <span>High estimate</span>
+      <strong data-output="highTotal">$0</strong>
+    </div>
+    <div>
+      <span>Contingency added</span>
+      <strong data-output="contingency">$0</strong>
+    </div>
+  </div>
+
+  <div class="calculator-breakdown">
+    <h3>Category ranges</h3>
+    <dl data-output="breakdown"></dl>
+  </div>
+
+  <div class="calculator-tool__cta">
+    <p>Save the scoped estimate, photos, notes, and PDF report in Rehab Estimator.</p>
+    {% include download_cta.html %}
+  </div>
+</section>

--- a/_includes/calculator_tools/rental_cashflow.html
+++ b/_includes/calculator_tools/rental_cashflow.html
@@ -1,0 +1,88 @@
+<section class="calculator-tool" data-calculator="rental-cashflow">
+  <div class="calculator-tool__header">
+    <h2>Rental Cashflow Calculator</h2>
+    <p>Estimate monthly cashflow, cash invested, and cash-on-cash return with rehab and operating assumptions.</p>
+  </div>
+
+  <form class="calculator-form">
+    <label>
+      <span>Purchase price</span>
+      <input type="number" min="1" step="5000" value="220000" data-input="purchasePrice" inputmode="decimal">
+    </label>
+    <label>
+      <span>Rehab cost</span>
+      <input type="number" min="0" step="1000" value="30000" data-input="rehabCost" inputmode="decimal">
+    </label>
+    <label>
+      <span>Closing cost</span>
+      <input type="number" min="0" step="500" value="6000" data-input="closingCost" inputmode="decimal">
+    </label>
+    <label>
+      <span>Down payment</span>
+      <input type="number" min="0" max="100" step="1" value="20" data-input="downPaymentRate" inputmode="decimal">
+    </label>
+    <label>
+      <span>Interest rate</span>
+      <input type="number" min="0" max="30" step="0.125" value="7" data-input="interestRate" inputmode="decimal">
+    </label>
+    <label>
+      <span>Loan years</span>
+      <input type="number" min="1" max="40" step="1" value="30" data-input="loanYears" inputmode="decimal">
+    </label>
+    <label>
+      <span>Monthly rent</span>
+      <input type="number" min="0" step="50" value="2400" data-input="rent" inputmode="decimal">
+    </label>
+    <label>
+      <span>Vacancy</span>
+      <input type="number" min="0" max="100" step="1" value="5" data-input="vacancyRate" inputmode="decimal">
+    </label>
+    <label>
+      <span>Management</span>
+      <input type="number" min="0" max="100" step="1" value="8" data-input="managementRate" inputmode="decimal">
+    </label>
+    <label>
+      <span>Maintenance</span>
+      <input type="number" min="0" max="100" step="1" value="5" data-input="maintenanceRate" inputmode="decimal">
+    </label>
+    <label>
+      <span>Annual taxes</span>
+      <input type="number" min="0" step="100" value="3600" data-input="annualTaxes" inputmode="decimal">
+    </label>
+    <label>
+      <span>Annual insurance</span>
+      <input type="number" min="0" step="100" value="1800" data-input="annualInsurance" inputmode="decimal">
+    </label>
+    <label>
+      <span>Misc monthly</span>
+      <input type="number" min="0" step="25" value="75" data-input="miscMonthly" inputmode="decimal">
+    </label>
+  </form>
+
+  <p class="calculator-error" data-error aria-live="polite"></p>
+
+  <div class="calculator-results" aria-live="polite">
+    <div>
+      <span>Monthly cashflow</span>
+      <strong data-output="monthlyCashflow">$0</strong>
+    </div>
+    <div>
+      <span>Cash invested</span>
+      <strong data-output="cashInvested">$0</strong>
+    </div>
+    <div>
+      <span>Cash-on-cash return</span>
+      <strong data-output="cashOnCashReturn">0%</strong>
+    </div>
+  </div>
+
+  <div class="calculator-breakdown">
+    <h3>Monthly expense summary</h3>
+    <dl data-output="breakdown"></dl>
+  </div>
+
+  <div class="calculator-tool__cta">
+    <p>Save the rental assumptions with repair photos, notes, and a PDF estimate in Rehab Estimator.</p>
+    {% include download_cta.html %}
+  </div>
+</section>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -15,6 +15,11 @@
     </article>
   </main>
   {% include footer.html %}
+  {% if page.scripts %}
+    {% for script in page.scripts %}
+  <script src="{{ script | relative_url }}" defer></script>
+    {% endfor %}
+  {% endif %}
 </body>
 
 </html>

--- a/_pages/fix-and-flip-calculator.md
+++ b/_pages/fix-and-flip-calculator.md
@@ -5,6 +5,10 @@ seo_title: Fix and Flip Calculator for Rehab Deals | Rehab Estimator
 meta_description: Calculate flip profit with purchase price, rehab budget, ARV, holding costs, selling costs, financing, and contingency.
 include_in_header: false
 permalink: /fix-and-flip-calculator/
+scripts:
+  - /assets/js/calculators/formulas.js
+  - /assets/js/calculators/ui.js
+  - /assets/js/calculators/fix-flip.js
 faqs:
   - question: What numbers should a fix and flip calculator use?
     answer: A fix and flip calculator should include purchase price, after repair value, rehab cost, closing costs, holding costs, selling costs, financing costs, contingency, and target profit.
@@ -29,6 +33,8 @@ related_calculators:
   <h1>Pressure-test a flip with repair, resale, holding, and selling costs.</h1>
   <p>Connect the rehab estimate to the deal model so a stronger resale price does not hide a weak repair budget.</p>
 </div>
+
+{% include calculator_tools/fix_flip.html %}
 
 ## What to calculate before making an offer
 

--- a/_pages/rehab-cost-calculator.md
+++ b/_pages/rehab-cost-calculator.md
@@ -5,6 +5,10 @@ seo_title: Rehab Cost Calculator for Property Repairs | Rehab Estimator
 meta_description: Build a rehab cost estimate by room, scope category, quantity, and cost range before turning it into a PDF report.
 include_in_header: false
 permalink: /rehab-cost-calculator/
+scripts:
+  - /assets/js/calculators/formulas.js
+  - /assets/js/calculators/ui.js
+  - /assets/js/calculators/rehab-cost.js
 faqs:
   - question: What should a rehab cost calculator include?
     answer: A rehab cost calculator should include interior, exterior, and project-level work, plus quantities, low-to-high cost ranges, photos, and notes that explain why each repair is in the estimate.
@@ -29,6 +33,8 @@ related_calculators:
   <h1>Build a room-by-room rehab cost estimate before you make the offer.</h1>
   <p>Use scope categories, quantities, photos, and low-to-high cost ranges to turn a walkthrough into a repair budget that can be reviewed and shared.</p>
 </div>
+
+{% include calculator_tools/rehab_cost.html %}
 
 ## What to capture during the walkthrough
 

--- a/_pages/rental-cashflow-calculator.md
+++ b/_pages/rental-cashflow-calculator.md
@@ -5,6 +5,10 @@ seo_title: Rental Cashflow Calculator with Rehab Costs | Rehab Estimator
 meta_description: Estimate rental cashflow with rent, debt service, vacancy, taxes, insurance, maintenance, management, and repair costs.
 include_in_header: false
 permalink: /rental-cashflow-calculator/
+scripts:
+  - /assets/js/calculators/formulas.js
+  - /assets/js/calculators/ui.js
+  - /assets/js/calculators/rental-cashflow.js
 faqs:
   - question: What expenses should a rental cashflow calculator include?
     answer: A rental cashflow calculator should include rent, mortgage payment, taxes, insurance, vacancy, maintenance, property management, utilities paid by the owner, capital reserves, and repair costs needed before rent starts.
@@ -29,6 +33,8 @@ related_calculators:
   <h1>See whether a rental still cashflows after the repair budget.</h1>
   <p>Model the income, operating expenses, debt, vacancy, reserves, and rehab assumptions that decide whether a property is actually rent-ready.</p>
 </div>
+
+{% include calculator_tools/rental_cashflow.html %}
 
 ## Inputs worth checking before buying
 

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -544,6 +544,138 @@ main {
   line-height: 1.45;
 }
 
+.calculator-tool {
+  margin: 0 0 34px;
+  padding: 24px;
+  border: 1px solid $soft-border-color;
+  border-radius: 8px;
+  background: $surface-color;
+}
+
+.calculator-tool__header h2 {
+  color: $primary-text-color;
+  font-size: 2.8rem;
+  line-height: 1.2;
+}
+
+.calculator-tool__header p {
+  margin-top: 8px;
+  color: $muted-text-color;
+}
+
+.calculator-form {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.calculator-form label {
+  display: grid;
+  gap: 7px;
+}
+
+.calculator-form span {
+  color: $ink-soft-color;
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.calculator-form input,
+.calculator-form select {
+  width: 100%;
+  min-width: 0;
+  min-height: 44px;
+  padding: 9px 11px;
+  border: 1px solid $soft-border-color;
+  border-radius: 8px;
+  color: $primary-text-color;
+  background: $paper-color;
+}
+
+.calculator-form input:focus,
+.calculator-form select:focus {
+  border-color: $accent-color;
+  outline: 2px solid rgba($accent-color, 0.16);
+  outline-offset: 1px;
+}
+
+.calculator-error {
+  min-height: 24px;
+  margin-top: 14px;
+  color: #9b3516;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.calculator-results {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.calculator-results div {
+  padding: 16px;
+  border: 1px solid rgba($soft-border-color, 0.86);
+  border-radius: 8px;
+  background: $paper-color;
+}
+
+.calculator-results span {
+  display: block;
+  color: $muted-text-color;
+  font-size: 1.35rem;
+}
+
+.calculator-results strong {
+  display: block;
+  margin-top: 7px;
+  color: $primary-text-color;
+  font-size: 2.3rem;
+  line-height: 1.15;
+}
+
+.calculator-breakdown {
+  margin-top: 20px;
+}
+
+.calculator-breakdown h3 {
+  color: $primary-text-color;
+  font-size: 1.9rem;
+}
+
+.calculator-breakdown dl {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px 16px;
+  margin-top: 12px;
+}
+
+.calculator-breakdown dt {
+  color: $muted-text-color;
+}
+
+.calculator-breakdown dd {
+  color: $primary-text-color;
+  font-weight: 750;
+  text-align: right;
+}
+
+.calculator-tool__cta {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid rgba($soft-border-color, 0.86);
+}
+
+.calculator-tool__cta p {
+  color: $muted-text-color;
+}
+
+.calculator-tool__cta .download-actions {
+  margin-top: 18px;
+}
+
 .page-cta {
   margin-top: 36px;
   padding: 28px;
@@ -738,6 +870,8 @@ main {
 
   .feature-grid,
   .seo-grid,
+  .calculator-form,
+  .calculator-results,
   .screenshot-grid,
   .footer-columns {
     grid-template-columns: 1fr;

--- a/assets/js/calculators/fix-flip.js
+++ b/assets/js/calculators/fix-flip.js
@@ -1,0 +1,32 @@
+(function() {
+  "use strict";
+
+  const formulas = window.RehabCalculatorFormulas;
+  const ui = window.RehabCalculatorUI;
+  const container = document.querySelector('[data-calculator="fix-flip"]');
+  if (!container || !formulas || !ui) return;
+
+  ui.bindCalculator(container, () => {
+    const result = formulas.fixAndFlip({
+      arv: ui.readNumber(container, "arv"),
+      purchasePrice: ui.readNumber(container, "purchasePrice"),
+      desiredProfit: ui.readNumber(container, "desiredProfit"),
+      repairCost: ui.readNumber(container, "repairCost"),
+      purchaseCost: ui.readNumber(container, "purchaseCost"),
+      saleCost: ui.readNumber(container, "saleCost"),
+      monthlyHoldingCost: ui.readNumber(container, "monthlyHoldingCost"),
+      holdingMonths: ui.readNumber(container, "holdingMonths"),
+      commissionRate: ui.readNumber(container, "commissionRate")
+    });
+
+    ui.setText(container, "maxPurchasePrice", ui.formatCurrency(result.maxPurchasePrice));
+    ui.setText(container, "projectedProfit", ui.formatCurrency(result.projectedProfit));
+    ui.setText(container, "profitMargin", ui.formatPercent(result.profitMargin));
+    ui.renderBreakdown(container, [
+      { label: "Holding cost", value: ui.formatCurrency(result.holdingCost) },
+      { label: "Agent commission", value: ui.formatCurrency(result.commission) },
+      { label: "Non-purchase costs", value: ui.formatCurrency(result.nonPurchaseCost) },
+      { label: "Total project cost", value: ui.formatCurrency(result.totalProjectCost) }
+    ]);
+  });
+})();

--- a/assets/js/calculators/formulas.js
+++ b/assets/js/calculators/formulas.js
@@ -1,0 +1,148 @@
+(function(root) {
+  "use strict";
+
+  const REHAB_RATES = {
+    light: { label: "Light cosmetic", low: 15, high: 35 },
+    medium: { label: "Medium rehab", low: 35, high: 70 },
+    heavy: { label: "Heavy rehab", low: 70, high: 120 }
+  };
+
+  const REHAB_CATEGORY_WEIGHTS = [
+    ["Interior", 0.55],
+    ["Exterior", 0.20],
+    ["Systems", 0.18],
+    ["General", 0.07]
+  ];
+
+  function assertFiniteNumber(value, label) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) {
+      throw new Error(`${label} must be a number.`);
+    }
+    return number;
+  }
+
+  function assertMin(value, label, min) {
+    const number = assertFiniteNumber(value, label);
+    if (number < min) {
+      throw new Error(`${label} must be at least ${min}.`);
+    }
+    return number;
+  }
+
+  function percent(value) {
+    return assertMin(value, "Percent", 0) / 100;
+  }
+
+  function monthlyPayment(principal, annualRate, years) {
+    const loanAmount = assertMin(principal, "Loan amount", 0);
+    const termYears = assertMin(years, "Loan years", 1);
+    const monthlyRate = assertMin(annualRate, "Interest rate", 0) / 100 / 12;
+    const payments = termYears * 12;
+
+    if (loanAmount === 0) return 0;
+    if (monthlyRate === 0) return loanAmount / payments;
+
+    const factor = Math.pow(1 + monthlyRate, payments);
+    return loanAmount * ((monthlyRate * factor) / (factor - 1));
+  }
+
+  function rehabCost(inputs) {
+    const squareFeet = assertMin(inputs.squareFeet, "Square footage", 1);
+    const contingencyRate = percent(inputs.contingencyRate || 0);
+    const rate = REHAB_RATES[inputs.intensity] || REHAB_RATES.medium;
+    const baseLow = squareFeet * rate.low;
+    const baseHigh = squareFeet * rate.high;
+    const lowTotal = baseLow * (1 + contingencyRate);
+    const highTotal = baseHigh * (1 + contingencyRate);
+
+    return {
+      intensityLabel: rate.label,
+      lowTotal,
+      highTotal,
+      contingency: highTotal - baseHigh,
+      breakdown: REHAB_CATEGORY_WEIGHTS.map(([label, weight]) => ({
+        label,
+        low: lowTotal * weight,
+        high: highTotal * weight
+      }))
+    };
+  }
+
+  function fixAndFlip(inputs) {
+    const arv = assertMin(inputs.arv, "After repair value", 1);
+    const purchasePrice = assertMin(inputs.purchasePrice, "Purchase price", 0);
+    const desiredProfit = assertMin(inputs.desiredProfit, "Desired profit", 0);
+    const repairCost = assertMin(inputs.repairCost, "Repair cost", 0);
+    const purchaseCost = assertMin(inputs.purchaseCost, "Purchase costs", 0);
+    const saleCost = assertMin(inputs.saleCost, "Selling costs", 0);
+    const monthlyHoldingCost = assertMin(inputs.monthlyHoldingCost, "Holding cost per month", 0);
+    const holdingMonths = assertMin(inputs.holdingMonths, "Holding months", 0);
+    const commission = arv * percent(inputs.commissionRate || 0);
+    const holdingCost = monthlyHoldingCost * holdingMonths;
+    const nonPurchaseCost = repairCost + purchaseCost + saleCost + holdingCost + commission;
+    const maxPurchasePrice = arv - desiredProfit - nonPurchaseCost;
+    const projectedProfit = arv - purchasePrice - nonPurchaseCost;
+
+    return {
+      maxPurchasePrice,
+      projectedProfit,
+      profitMargin: projectedProfit / arv,
+      totalProjectCost: purchasePrice + nonPurchaseCost,
+      holdingCost,
+      commission,
+      nonPurchaseCost
+    };
+  }
+
+  function rentalCashflow(inputs) {
+    const purchasePrice = assertMin(inputs.purchasePrice, "Purchase price", 1);
+    const rehabCostValue = assertMin(inputs.rehabCost, "Rehab cost", 0);
+    const closingCost = assertMin(inputs.closingCost, "Closing cost", 0);
+    const downPaymentRate = percent(inputs.downPaymentRate || 0);
+    const rent = assertMin(inputs.rent, "Monthly rent", 0);
+    const annualTaxes = assertMin(inputs.annualTaxes, "Annual taxes", 0);
+    const annualInsurance = assertMin(inputs.annualInsurance, "Annual insurance", 0);
+    const miscMonthly = assertMin(inputs.miscMonthly, "Misc monthly", 0);
+
+    const downPayment = purchasePrice * downPaymentRate;
+    const loanAmount = Math.max(purchasePrice - downPayment, 0);
+    const loanPayment = monthlyPayment(loanAmount, inputs.interestRate || 0, inputs.loanYears || 30);
+    const vacancy = rent * percent(inputs.vacancyRate || 0);
+    const management = rent * percent(inputs.managementRate || 0);
+    const maintenance = rent * percent(inputs.maintenanceRate || 0);
+    const taxes = annualTaxes / 12;
+    const insurance = annualInsurance / 12;
+    const operatingExpenses = vacancy + management + maintenance + taxes + insurance + miscMonthly;
+    const monthlyCashflow = rent - loanPayment - operatingExpenses;
+    const cashInvested = downPayment + rehabCostValue + closingCost;
+
+    return {
+      monthlyCashflow,
+      cashInvested,
+      cashOnCashReturn: cashInvested > 0 ? (monthlyCashflow * 12) / cashInvested : 0,
+      loanAmount,
+      loanPayment,
+      operatingExpenses,
+      vacancy,
+      management,
+      maintenance,
+      taxes,
+      insurance,
+      miscMonthly
+    };
+  }
+
+  const formulas = {
+    rehabCost,
+    fixAndFlip,
+    rentalCashflow,
+    monthlyPayment
+  };
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = formulas;
+  } else {
+    root.RehabCalculatorFormulas = formulas;
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/assets/js/calculators/rehab-cost.js
+++ b/assets/js/calculators/rehab-cost.js
@@ -1,0 +1,24 @@
+(function() {
+  "use strict";
+
+  const formulas = window.RehabCalculatorFormulas;
+  const ui = window.RehabCalculatorUI;
+  const container = document.querySelector('[data-calculator="rehab-cost"]');
+  if (!container || !formulas || !ui) return;
+
+  ui.bindCalculator(container, () => {
+    const result = formulas.rehabCost({
+      squareFeet: ui.readNumber(container, "squareFeet"),
+      intensity: ui.readValue(container, "intensity"),
+      contingencyRate: ui.readNumber(container, "contingencyRate")
+    });
+
+    ui.setText(container, "lowTotal", ui.formatCurrency(result.lowTotal));
+    ui.setText(container, "highTotal", ui.formatCurrency(result.highTotal));
+    ui.setText(container, "contingency", ui.formatCurrency(result.contingency));
+    ui.renderBreakdown(container, result.breakdown.map((row) => ({
+      label: row.label,
+      value: `${ui.formatCurrency(row.low)} to ${ui.formatCurrency(row.high)}`
+    })));
+  });
+})();

--- a/assets/js/calculators/rental-cashflow.js
+++ b/assets/js/calculators/rental-cashflow.js
@@ -1,0 +1,38 @@
+(function() {
+  "use strict";
+
+  const formulas = window.RehabCalculatorFormulas;
+  const ui = window.RehabCalculatorUI;
+  const container = document.querySelector('[data-calculator="rental-cashflow"]');
+  if (!container || !formulas || !ui) return;
+
+  ui.bindCalculator(container, () => {
+    const result = formulas.rentalCashflow({
+      purchasePrice: ui.readNumber(container, "purchasePrice"),
+      rehabCost: ui.readNumber(container, "rehabCost"),
+      closingCost: ui.readNumber(container, "closingCost"),
+      downPaymentRate: ui.readNumber(container, "downPaymentRate"),
+      interestRate: ui.readNumber(container, "interestRate"),
+      loanYears: ui.readNumber(container, "loanYears"),
+      rent: ui.readNumber(container, "rent"),
+      vacancyRate: ui.readNumber(container, "vacancyRate"),
+      managementRate: ui.readNumber(container, "managementRate"),
+      maintenanceRate: ui.readNumber(container, "maintenanceRate"),
+      annualTaxes: ui.readNumber(container, "annualTaxes"),
+      annualInsurance: ui.readNumber(container, "annualInsurance"),
+      miscMonthly: ui.readNumber(container, "miscMonthly")
+    });
+
+    ui.setText(container, "monthlyCashflow", ui.formatCurrency(result.monthlyCashflow));
+    ui.setText(container, "cashInvested", ui.formatCurrency(result.cashInvested));
+    ui.setText(container, "cashOnCashReturn", ui.formatPercent(result.cashOnCashReturn));
+    ui.renderBreakdown(container, [
+      { label: "Loan payment", value: ui.formatCurrency(result.loanPayment) },
+      { label: "Vacancy", value: ui.formatCurrency(result.vacancy) },
+      { label: "Management", value: ui.formatCurrency(result.management) },
+      { label: "Maintenance", value: ui.formatCurrency(result.maintenance) },
+      { label: "Taxes and insurance", value: ui.formatCurrency(result.taxes + result.insurance) },
+      { label: "Operating expenses", value: ui.formatCurrency(result.operatingExpenses) }
+    ]);
+  });
+})();

--- a/assets/js/calculators/ui.js
+++ b/assets/js/calculators/ui.js
@@ -1,0 +1,75 @@
+(function(root) {
+  "use strict";
+
+  function formatCurrency(value) {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0
+    }).format(Number.isFinite(value) ? value : 0);
+  }
+
+  function formatPercent(value) {
+    return new Intl.NumberFormat("en-US", {
+      style: "percent",
+      maximumFractionDigits: 1
+    }).format(Number.isFinite(value) ? value : 0);
+  }
+
+  function readNumber(container, name) {
+    const input = container.querySelector(`[data-input="${name}"]`);
+    return input ? Number(input.value) : 0;
+  }
+
+  function readValue(container, name) {
+    const input = container.querySelector(`[data-input="${name}"]`);
+    return input ? input.value : "";
+  }
+
+  function setText(container, name, value) {
+    const output = container.querySelector(`[data-output="${name}"]`);
+    if (output) output.textContent = value;
+  }
+
+  function setError(container, message) {
+    const error = container.querySelector("[data-error]");
+    if (error) error.textContent = message || "";
+  }
+
+  function renderBreakdown(container, rows) {
+    const list = container.querySelector('[data-output="breakdown"]');
+    if (!list) return;
+
+    list.innerHTML = rows.map((row) => (
+      `<dt>${row.label}</dt><dd>${row.value}</dd>`
+    )).join("");
+  }
+
+  function bindCalculator(container, render) {
+    const form = container.querySelector(".calculator-form");
+    const update = () => {
+      try {
+        render();
+        setError(container, "");
+      } catch (error) {
+        setError(container, error.message);
+      }
+    };
+
+    if (form) {
+      form.addEventListener("input", update);
+      form.addEventListener("change", update);
+    }
+    update();
+  }
+
+  root.RehabCalculatorUI = {
+    bindCalculator,
+    formatCurrency,
+    formatPercent,
+    readNumber,
+    readValue,
+    renderBreakdown,
+    setText
+  };
+})(window);

--- a/tests/calculator-formulas.test.js
+++ b/tests/calculator-formulas.test.js
@@ -1,0 +1,62 @@
+const assert = require("assert");
+const formulas = require("../assets/js/calculators/formulas");
+
+function closeTo(actual, expected, tolerance = 0.01) {
+  assert.ok(Math.abs(actual - expected) <= tolerance, `${actual} was not within ${tolerance} of ${expected}`);
+}
+
+const rehab = formulas.rehabCost({
+  squareFeet: 1000,
+  intensity: "light",
+  contingencyRate: 10
+});
+
+closeTo(rehab.lowTotal, 16500);
+closeTo(rehab.highTotal, 38500);
+closeTo(rehab.contingency, 3500);
+assert.strictEqual(rehab.breakdown.length, 4);
+
+const flip = formulas.fixAndFlip({
+  arv: 300000,
+  purchasePrice: 180000,
+  desiredProfit: 40000,
+  repairCost: 35000,
+  purchaseCost: 5000,
+  saleCost: 4000,
+  monthlyHoldingCost: 1500,
+  holdingMonths: 4,
+  commissionRate: 6
+});
+
+closeTo(flip.commission, 18000);
+closeTo(flip.holdingCost, 6000);
+closeTo(flip.maxPurchasePrice, 192000);
+closeTo(flip.projectedProfit, 52000);
+closeTo(flip.profitMargin, 0.1733333333);
+
+const rental = formulas.rentalCashflow({
+  purchasePrice: 200000,
+  rehabCost: 30000,
+  closingCost: 5000,
+  downPaymentRate: 20,
+  interestRate: 6,
+  loanYears: 30,
+  rent: 2200,
+  vacancyRate: 5,
+  managementRate: 8,
+  maintenanceRate: 5,
+  annualTaxes: 3600,
+  annualInsurance: 1200,
+  miscMonthly: 50
+});
+
+closeTo(rental.loanAmount, 160000);
+closeTo(rental.loanPayment, 959.28, 0.1);
+closeTo(rental.cashInvested, 75000);
+closeTo(rental.operatingExpenses, 846);
+closeTo(rental.monthlyCashflow, 394.72, 0.1);
+closeTo(rental.cashOnCashReturn, 0.063155, 0.0002);
+
+assert.throws(() => formulas.rehabCost({ squareFeet: 0, intensity: "light" }), /Square footage/);
+
+console.log("calculator formula tests passed");


### PR DESCRIPTION
## Summary
- Adds client-side tools to the rehab cost, fix and flip, and rental cashflow pages.
- Adds static calculator includes, shared formula JS, page-specific bindings, and normal form/result styling.
- Keeps App Store and Play Store CTAs directly after each result area.
- Adds Node formula tests for the rehab, flip, rental, mortgage, and validation paths.

## Base
This PR now targets `main`. #10 and #11 are merged, and this branch was rebased onto the updated main branch.

## Validation
- `bundle exec jekyll build --quiet`
- `node tests/calculator-formulas.test.js`
- `for f in assets/js/calculators/*.js tests/calculator-formulas.test.js; do node --check "$f" || exit 1; done`
- `git diff --check`
- Bundled Playwright rendered generated HTML at 390px and 1280px without starting a local server.

Rendered check output:
```text
rehab-cost-calculator: rendered at 390px and 1280px, output updated, no horizontal overflow
fix-and-flip-calculator: rendered at 390px and 1280px, output updated, no horizontal overflow
rental-cashflow-calculator: rendered at 390px and 1280px, output updated, no horizontal overflow
```

## Manual test matrix
- Rehab cost: change square footage, intensity, and contingency. Low/high range and category ranges update.
- Fix and flip: change ARV, purchase price, repair cost, holding period, and commission. Maximum purchase price, projected profit, and margin update.
- Rental cashflow: change purchase price, rent, down payment, expenses, and loan terms. Monthly cashflow, cash invested, and cash-on-cash return update.
- Invalid values: zero square footage or invalid loan years show inline errors.

Closes #4