### PR TITLE
feat: Add SEO measurement tracking (#8)

### DIFF
--- a/_includes/calculator_tools/fix_flip.html
+++ b/_includes/calculator_tools/fix_flip.html
@@ -67,6 +67,6 @@
 
   <div class="calculator-tool__cta">
     <p>Save the deal assumptions with the repair scope, photos, and PDF report in Rehab Estimator.</p>
-    {% include download_cta.html %}
+    {% include download_cta.html location="calculator_result" %}
   </div>
 </section>

--- a/_includes/calculator_tools/rehab_cost.html
+++ b/_includes/calculator_tools/rehab_cost.html
@@ -47,6 +47,6 @@
 
   <div class="calculator-tool__cta">
     <p>Save the scoped estimate, photos, notes, and PDF report in Rehab Estimator.</p>
-    {% include download_cta.html %}
+    {% include download_cta.html location="calculator_result" %}
   </div>
 </section>

--- a/_includes/calculator_tools/rental_cashflow.html
+++ b/_includes/calculator_tools/rental_cashflow.html
@@ -83,6 +83,6 @@
 
   <div class="calculator-tool__cta">
     <p>Save the rental assumptions with repair photos, notes, and a PDF estimate in Rehab Estimator.</p>
-    {% include download_cta.html %}
+    {% include download_cta.html location="calculator_result" %}
   </div>
 </section>

--- a/_includes/download_cta.html
+++ b/_includes/download_cta.html
@@ -1,8 +1,8 @@
 <div class="download-actions">
-  <a class="store-badge" href="{{ site.appstore_link }}" aria-label="Download on the App Store">
+  <a class="store-badge" href="{{ site.appstore_link }}" aria-label="Download on the App Store" data-analytics-event="app_store_cta_click" data-store="app_store" data-cta-location="{{ include.location | default: 'download_cta' }}">
     <img src="{{ '/assets/appstore.png' | relative_url }}" alt="Download on the App Store" />
   </a>
-  <a class="store-badge" href="{{ site.playstore_link }}" aria-label="Get it on Google Play">
+  <a class="store-badge" href="{{ site.playstore_link }}" aria-label="Get it on Google Play" data-analytics-event="play_store_cta_click" data-store="play_store" data-cta-location="{{ include.location | default: 'download_cta' }}">
     <img src="{{ '/assets/playstore.png' | relative_url }}" alt="Get it on Google Play" />
   </a>
 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,6 +7,6 @@
     <a href="{{ '/#product' | relative_url }}" target="_self">Product</a>
     <a href="{{ '/#proof' | relative_url }}" target="_self">Proof</a>
     <a href="{{ '/rehab-cost-calculator/' | relative_url }}" target="_self">Calculators</a>
-    <a href="{{ site.appstore_link }}" class="nav-cta">Download</a>
+    <a href="{{ site.appstore_link }}" class="nav-cta" data-analytics-event="app_store_cta_click" data-store="app_store" data-cta-location="header">Download</a>
   </nav>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -148,5 +148,6 @@
   </main>
 
   {% include footer.html %}
+  <script src="{{ '/assets/js/analytics.js' | relative_url }}" defer></script>
 </body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -15,6 +15,7 @@
     </article>
   </main>
   {% include footer.html %}
+  <script src="{{ '/assets/js/analytics.js' | relative_url }}" defer></script>
   {% if page.scripts %}
     {% for script in page.scripts %}
   <script src="{{ script | relative_url }}" defer></script>

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,0 +1,61 @@
+(function(root) {
+  "use strict";
+
+  const trackedResults = new Set();
+
+  function pagePath() {
+    return root.location ? root.location.pathname : "";
+  }
+
+  function calculatorNameFromPath(path) {
+    if (path.includes("rehab-cost-calculator")) return "rehab_cost";
+    if (path.includes("fix-and-flip-calculator")) return "fix_and_flip";
+    if (path.includes("rental-cashflow-calculator")) return "rental_cashflow";
+    return "";
+  }
+
+  function send(eventName, params) {
+    if (typeof root.gtag !== "function") return;
+    root.gtag("event", eventName, Object.assign({
+      page_path: pagePath()
+    }, params || {}));
+  }
+
+  function trackCalculatorResult(calculatorName) {
+    const key = `${pagePath()}:${calculatorName}`;
+    if (trackedResults.has(key)) return;
+    trackedResults.add(key);
+    send("calculator_result_generated", {
+      calculator_name: calculatorName
+    });
+  }
+
+  document.addEventListener("click", (event) => {
+    const link = event.target.closest("[data-analytics-event]");
+    if (!link) return;
+
+    const store = link.dataset.store || "";
+    const ctaLocation = link.dataset.ctaLocation || "unknown";
+    const linkUrl = link.href || "";
+    const calculatorName = calculatorNameFromPath(pagePath());
+
+    send(link.dataset.analyticsEvent, {
+      store,
+      cta_location: ctaLocation,
+      link_url: linkUrl
+    });
+
+    if (calculatorName) {
+      send("calculator_page_cta_click", {
+        calculator_name: calculatorName,
+        store,
+        cta_location: ctaLocation,
+        link_url: linkUrl
+      });
+    }
+  });
+
+  root.RehabAnalytics = {
+    trackCalculatorResult
+  };
+})(window);

--- a/assets/js/calculators/fix-flip.js
+++ b/assets/js/calculators/fix-flip.js
@@ -28,5 +28,8 @@
       { label: "Non-purchase costs", value: ui.formatCurrency(result.nonPurchaseCost) },
       { label: "Total project cost", value: ui.formatCurrency(result.totalProjectCost) }
     ]);
+    if (window.RehabAnalytics) {
+      window.RehabAnalytics.trackCalculatorResult("fix_and_flip");
+    }
   });
 })();

--- a/assets/js/calculators/rehab-cost.js
+++ b/assets/js/calculators/rehab-cost.js
@@ -20,5 +20,8 @@
       label: row.label,
       value: `${ui.formatCurrency(row.low)} to ${ui.formatCurrency(row.high)}`
     })));
+    if (window.RehabAnalytics) {
+      window.RehabAnalytics.trackCalculatorResult("rehab_cost");
+    }
   });
 })();

--- a/assets/js/calculators/rental-cashflow.js
+++ b/assets/js/calculators/rental-cashflow.js
@@ -34,5 +34,8 @@
       { label: "Taxes and insurance", value: ui.formatCurrency(result.taxes + result.insurance) },
       { label: "Operating expenses", value: ui.formatCurrency(result.operatingExpenses) }
     ]);
+    if (window.RehabAnalytics) {
+      window.RehabAnalytics.trackCalculatorResult("rental_cashflow");
+    }
   });
 })();

--- a/docs/seo-monitoring-runbook.md
+++ b/docs/seo-monitoring-runbook.md
@@ -1,0 +1,106 @@
+# SEO Monitoring Runbook
+
+## Baseline
+
+Recorded from Google Search Console on May 15, 2026:
+
+- Property: `rehabestimator.app`
+- Page indexing last update: May 11, 2026
+- Indexed pages: 0
+- Not indexed pages: 6
+- Current not indexed reason: `Crawled - currently not indexed`
+- Validation status: `Not Started`
+- Performance, last 3 months: 0 clicks, 0 impressions
+- Query data: none
+- Page data: none
+- Sitemap: `https://app.rehabestimator.app/sitemap.xml`
+- Sitemap status after submission: `Success`
+- Sitemap last read: May 15, 2026
+- Sitemap discovered pages: 10
+
+## Weekly Check
+
+Run this check once per week after sitemap or calculator page changes deploy.
+
+1. Open Search Console for `rehabestimator.app`.
+2. Record Page indexing:
+   - Indexed pages count
+   - Not indexed pages count
+   - Top not indexed reason
+   - Validation state
+   - Last update date
+3. Open Sitemaps:
+   - Submitted sitemap URL
+   - Status
+   - Last read date
+   - Discovered pages
+4. Open Performance, Search results, last 3 months:
+   - Total clicks
+   - Total impressions
+   - Average CTR
+   - Average position
+   - Top queries
+   - Top pages
+5. Compare calculator pages:
+   - `/rehab-cost-calculator/`
+   - `/fix-and-flip-calculator/`
+   - `/rental-cashflow-calculator/`
+   - `/kitchen-remodel-cost-estimator/`
+   - `/bathroom-remodel-cost-estimator/`
+6. Record changes in the active SEO issue or a dated note in this file.
+
+## GA Events
+
+Google Analytics is configured with `G-CW74KH0YSC`.
+
+Tracked landing-page conversion events:
+
+| Event | Trigger | Required parameters |
+| --- | --- | --- |
+| `app_store_cta_click` | App Store CTA click | `page_path`, `store`, `cta_location`, `link_url` |
+| `play_store_cta_click` | Play Store CTA click | `page_path`, `store`, `cta_location`, `link_url` |
+| `calculator_result_generated` | First valid calculator result per page load | `page_path`, `calculator_name` |
+| `calculator_page_cta_click` | App Store or Play Store CTA click from a calculator page | `page_path`, `calculator_name`, `store`, `cta_location`, `link_url` |
+
+Do not send user-entered calculator values to GA. The event only records that a result was generated and which calculator page was used.
+
+CTA locations currently used:
+
+- `header`
+- `download_cta`
+- `calculator_result`
+
+## Search Console Response
+
+### URL is unknown to Google
+
+1. Confirm the URL returns 200.
+2. Confirm the page has a self-referencing canonical tag.
+3. Confirm the page is included in `sitemap.xml` when it is index-worthy.
+4. Submit the sitemap again if the sitemap was missing or stale.
+5. Request indexing for the canonical URL.
+
+### Crawled - currently not indexed
+
+1. Export or record the exact URLs.
+2. Classify each URL as a primary SEO page, support/legal page, or duplicate tracking URL.
+3. For primary SEO pages, improve visible content, internal links, and supported structured data.
+4. For duplicate tracking URLs, keep the canonical target clean and request indexing only for the canonical URL.
+5. For support pages, decide whether to leave indexable or add `noindex`.
+6. Start validation only after relevant fixes are deployed.
+
+### Sitemap read errors
+
+1. Open `https://app.rehabestimator.app/sitemap.xml`.
+2. Confirm it returns 200 XML.
+3. Confirm `robots.txt` points to the canonical sitemap URL.
+4. Confirm sitemap entries are canonical and indexable.
+5. Re-submit the sitemap after the deployed file is fixed.
+
+### Zero impressions after indexing
+
+1. Confirm target pages are indexed with URL Inspection.
+2. Check whether impressions are filtered by date range, country, or search type.
+3. Improve page intent coverage, FAQs, internal links, and visible tool value.
+4. Compare each calculator page in Performance by page path.
+5. If indexed pages still have no impressions after two to four weeks, add more specific long-tail pages or improve snippets and internal links.


### PR DESCRIPTION
## Summary
- Adds a concise SEO monitoring runbook with the first Search Console baseline values.
- Tracks App Store and Play Store CTA clicks with page path, store, CTA location, and link URL.
- Tracks calculator result generation once per page load after #4 calculators produce a valid result.
- Tracks calculator-page CTA clicks segmented by calculator name and page path.

## Base
This PR now targets `main`. #12 is merged, and this branch was rebased onto the updated main branch.

## GA events
- `app_store_cta_click`
- `play_store_cta_click`
- `calculator_result_generated`
- `calculator_page_cta_click`

## Validation
- `bundle exec jekyll build --quiet`
- `node tests/calculator-formulas.test.js`
- `for f in assets/js/analytics.js assets/js/calculators/*.js tests/calculator-formulas.test.js; do node --check "$f" || exit 1; done`
- `git diff --check`
- Bundled Playwright verified calculator result and CTA events include `page_path` and calculator segmentation.

Rendered event check output:
```text
rehab-cost-calculator: GA events emitted with page_path and calculator segmentation
fix-and-flip-calculator: GA events emitted with page_path and calculator segmentation
rental-cashflow-calculator: GA events emitted with page_path and calculator segmentation
```

Closes #8