### PR TITLE
feat: Add demand validation SEO pages (#3)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,21 @@ sitemap_urls:
   - path: /bathroom-remodel-cost-estimator/
     lastmod: "2026-05-15"
     priority: 0.8
+  - path: /contractor-bid-comparison/
+    lastmod: "2026-05-15"
+    priority: 0.7
+  - path: /rehab-estimate-spreadsheet/
+    lastmod: "2026-05-15"
+    priority: 0.7
+  - path: /scope-of-work-template-construction/
+    lastmod: "2026-05-15"
+    priority: 0.7
+  - path: /guided-property-walkthrough/
+    lastmod: "2026-05-15"
+    priority: 0.7
+  - path: /ai-rehab-scope-estimator/
+    lastmod: "2026-05-15"
+    priority: 0.7
   - path: /changelog/
     lastmod: "2026-05-15"
     priority: 0.4

--- a/_pages/ai-rehab-scope-estimator.md
+++ b/_pages/ai-rehab-scope-estimator.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: AI Rehab Scope Estimator
+seo_title: AI Rehab Scope Estimator Demand Page | Rehab Estimator
+meta_description: Learn how AI-assisted rehab scope ideas should be checked against real walkthrough notes, photos, and contractor pricing.
+include_in_header: false
+permalink: /ai-rehab-scope-estimator/
+---
+
+<div class="page-hero">
+  <p class="eyebrow">AI rehab scope estimator</p>
+  <h1>Use AI scope ideas carefully, then verify them in the field.</h1>
+  <p>Rehab Estimator focuses on structured repair capture, photos, calculators, and PDF reports. AI-assisted scope generation is a demand area, not a replacement for inspection.</p>
+</div>
+
+## Where AI can help
+
+AI can be useful for drafting checklists, reminding a user which categories to inspect, and turning rough notes into a cleaner scope outline. Those ideas still need to be checked against the actual property, local pricing, and contractor feedback.
+
+## Available in Rehab Estimator today
+
+- Capture repair tasks in structured categories.
+- Attach walkthrough photos and notes.
+- Estimate low-to-high rehab costs.
+- Use deal calculators for flip and rental decisions.
+- Export PDF reports for review.
+
+## What this page does not claim
+
+Rehab Estimator does not claim AI can inspect a property, guarantee repair accuracy, replace a contractor, or produce a final bid. Any AI-assisted scope should be treated as a draft that needs human review.
+
+## Related workflows
+
+- Start with the [guided property walkthrough](/guided-property-walkthrough/) to collect real evidence.
+- Build a repair range with the [rehab cost calculator](/rehab-cost-calculator/).
+- Turn the final scope into a [contractor-ready workflow](/scope-of-work-template-construction/).
+
+<div class="page-cta">
+  <h2>Capture the verified scope, not just the idea.</h2>
+  <p>Download Rehab Estimator for repair tasks, photos, calculators, and PDF reports.</p>
+  {% include download_cta.html %}
+</div>

--- a/_pages/contractor-bid-comparison.md
+++ b/_pages/contractor-bid-comparison.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Contractor Bid Comparison
+seo_title: Contractor Bid Comparison for Rehab Scopes | Rehab Estimator
+meta_description: Compare contractor bids against one repair scope using task-level estimates, photos, notes, and PDF reports.
+include_in_header: false
+permalink: /contractor-bid-comparison/
+---
+
+<div class="page-hero">
+  <p class="eyebrow">Contractor bid comparison</p>
+  <h1>Compare contractor bids against one scope of work.</h1>
+  <p>Use Rehab Estimator to keep the repair scope, cost ranges, and photos together before bid numbers start changing the conversation.</p>
+</div>
+
+## Why bid comparison needs one shared scope
+
+Contractor bids are hard to compare when each contractor prices a different version of the job. One bid may include demo, haul-off, and trim. Another may only include labor for the visible repair. A scope-backed estimate gives each contractor the same reference point.
+
+## Available in Rehab Estimator today
+
+- Build task-level rehab estimates by scope category.
+- Attach photos and notes to support each repair line.
+- Keep low-to-high cost ranges before contractor pricing is final.
+- Export a PDF report for review with partners, clients, or contractors.
+
+## Not claimed as automated bid analysis
+
+Rehab Estimator does not claim to automatically normalize contractor bids, detect every missing line item, or grade contractor quality. Use it as the scope record, then compare each bid manually against the same task list.
+
+## Related workflows
+
+- Start with the [rehab cost calculator](/rehab-cost-calculator/) to build the first repair range.
+- Use the [fix and flip calculator](/fix-and-flip-calculator/) to see whether bid changes still leave enough profit.
+- Use the [scope of work template workflow](/scope-of-work-template-construction/) when the estimate needs to become contractor-ready.
+
+<div class="page-cta">
+  <h2>Keep the scope consistent before bids arrive.</h2>
+  <p>Download Rehab Estimator to build the estimate, attach photos, and export a PDF scope.</p>
+  {% include download_cta.html %}
+</div>

--- a/_pages/guided-property-walkthrough.md
+++ b/_pages/guided-property-walkthrough.md
@@ -1,0 +1,42 @@
+---
+layout: page
+title: Guided Property Walkthrough
+seo_title: Guided Property Walkthrough for Rehab Estimates | Rehab Estimator
+meta_description: Use a structured property walkthrough workflow to capture repair tasks, photos, notes, and rehab estimate ranges.
+include_in_header: false
+permalink: /guided-property-walkthrough/
+---
+
+<div class="page-hero">
+  <p class="eyebrow">Guided property walkthrough</p>
+  <h1>Capture the repair scope while you are still at the property.</h1>
+  <p>Rehab Estimator keeps the estimate, property details, photos, and calculators close to the walkthrough.</p>
+</div>
+
+## A practical walkthrough sequence
+
+Start with exterior and systems, then move through the interior room by room. Capture obvious repairs first, then add notes for uncertain items that need measurement, contractor pricing, or inspection. Keep photos attached to the relevant tasks.
+
+## Available in Rehab Estimator today
+
+- Create a property report during the walkthrough.
+- Add repair tasks by category.
+- Attach photos and notes to support the estimate.
+- Use calculators for rehab cost, flip math, and rental cashflow.
+- Export a PDF report after the scope is ready to share.
+
+## What is not claimed
+
+This page does not claim a fully automated guided inspection or guaranteed repair detection. The workflow still depends on the person walking the property and the contractor or inspector feedback that follows.
+
+## Related workflows
+
+- Build the first range with the [rehab cost calculator](/rehab-cost-calculator/).
+- Convert notes into a [scope of work template](/scope-of-work-template-construction/).
+- Use the [rehab estimate spreadsheet alternative](/rehab-estimate-spreadsheet/) when photos and notes need to stay near the numbers.
+
+<div class="page-cta">
+  <h2>Keep walkthrough notes attached to the estimate.</h2>
+  <p>Download Rehab Estimator to capture repair tasks, photos, calculators, and PDF reports.</p>
+  {% include download_cta.html %}
+</div>

--- a/_pages/rehab-estimate-spreadsheet.md
+++ b/_pages/rehab-estimate-spreadsheet.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Rehab Estimate Spreadsheet
+seo_title: Rehab Estimate Spreadsheet Alternative | Rehab Estimator
+meta_description: Build task-level rehab estimates with categories, ranges, photos, and PDF reports instead of keeping every repair in a spreadsheet.
+include_in_header: false
+permalink: /rehab-estimate-spreadsheet/
+---
+
+<div class="page-hero">
+  <p class="eyebrow">Rehab estimate spreadsheet</p>
+  <h1>Move rehab estimate numbers out of a fragile spreadsheet.</h1>
+  <p>Rehab Estimator helps capture task-level repair costs, photo notes, and property details in a mobile-first workflow.</p>
+</div>
+
+## When a spreadsheet starts to break down
+
+Spreadsheets are flexible, but they become hard to trust when scope notes, photos, contractor feedback, and deal math live in different places. A repair total without the supporting task list is difficult to review after the walkthrough.
+
+## Available in Rehab Estimator today
+
+- Create property reports with task-level rehab costs.
+- Group repairs by interior, exterior, and general categories.
+- Attach photos to support line items.
+- Export a PDF report with the estimate and supporting details.
+
+## What this does not replace
+
+If you need custom spreadsheet formulas, portfolio rollups, or accounting workflows, a spreadsheet can still be useful. Rehab Estimator is built for field capture, repair estimating, calculators, and shareable PDF reports.
+
+## Related workflows
+
+- Use the [rehab cost calculator](/rehab-cost-calculator/) for a first-pass repair range.
+- Use the [rental cashflow calculator](/rental-cashflow-calculator/) when repair costs affect rent readiness.
+- Review [contractor bid comparison](/contractor-bid-comparison/) when spreadsheet line items need contractor feedback.
+
+<div class="page-cta">
+  <h2>Build the estimate where the walkthrough happens.</h2>
+  <p>Download Rehab Estimator for task-level repair ranges, photos, calculators, and PDF reports.</p>
+  {% include download_cta.html %}
+</div>

--- a/_pages/scope-of-work-template-construction.md
+++ b/_pages/scope-of-work-template-construction.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Scope of Work Template Construction
+seo_title: Scope of Work Template for Construction Rehab | Rehab Estimator
+meta_description: Create a construction scope of work from walkthrough notes, repair categories, photos, and PDF rehab estimate reports.
+include_in_header: false
+permalink: /scope-of-work-template-construction/
+---
+
+<div class="page-hero">
+  <p class="eyebrow">Scope of work template</p>
+  <h1>Turn walkthrough notes into a contractor-ready repair scope.</h1>
+  <p>Use Rehab Estimator to organize repair categories, quantities, cost ranges, photos, and notes before sharing the work.</p>
+</div>
+
+## What a useful scope of work template should contain
+
+A construction scope of work should separate tasks by area, describe the repair, record quantities when known, and preserve the reason behind the item. Photos and notes matter because they reduce confusion when the report is reviewed later.
+
+## Available in Rehab Estimator today
+
+- Start from rehab estimate categories and task lists.
+- Add custom repair items when a property needs a specific scope.
+- Attach photo documentation to the report.
+- Export a PDF for contractor, investor, or client review.
+
+## Planned or manual work
+
+Rehab Estimator does not claim that every contractor will price the PDF exactly the same way. Final trade pricing still needs contractor review, local labor assumptions, and material choices.
+
+## Related workflows
+
+- Use the [bathroom remodel cost estimator](/bathroom-remodel-cost-estimator/) for trade-heavy small rooms.
+- Use the [kitchen remodel cost estimator](/kitchen-remodel-cost-estimator/) for high-impact interior work.
+- Compare bids with the [contractor bid comparison workflow](/contractor-bid-comparison/).
+
+<div class="page-cta">
+  <h2>Create a scope from the same estimate you share.</h2>
+  <p>Download Rehab Estimator to build the task list, attach photos, and export a PDF report.</p>
+  {% include download_cta.html %}
+</div>


### PR DESCRIPTION
## Summary
- Adds five focused demand-validation landing pages for contractor bid comparison, rehab estimate spreadsheet searches, scope of work templates, guided walkthroughs, and AI rehab scope estimation demand.
- Keeps copy grounded in shipped Rehab Estimator capabilities and explicitly separates planned or manual work from available features.
- Adds internal links to related calculators and workflow pages.
- Adds the new canonical URLs to the `_config.yml` sitemap configuration introduced by #10.

## Base
This PR now targets `main`. #13 is merged, and this branch was rebased onto the updated main branch.

## Validation
- `bundle exec jekyll build --quiet`
- `ruby scripts/check_seo_crawl.rb --site-dir _site`
- `node tests/calculator-formulas.test.js`
- `for f in assets/js/analytics.js assets/js/calculators/*.js tests/calculator-formulas.test.js; do node --check "$f" || exit 1; done`
- `git diff --check`
- Generated HTML check confirmed each new page has canonical URL, sitemap coverage, App Store and Play Store tracking attributes, and at least 8 internal links.

Generated page check output:
```text
contractor-bid-comparison: canonical, sitemap, CTA tracking, 18 internal links
rehab-estimate-spreadsheet: canonical, sitemap, CTA tracking, 18 internal links
scope-of-work-template-construction: canonical, sitemap, CTA tracking, 18 internal links
guided-property-walkthrough: canonical, sitemap, CTA tracking, 18 internal links
ai-rehab-scope-estimator: canonical, sitemap, CTA tracking, 18 internal links
```

Closes #3