### PR TITLE
ci: Add Node 24 GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: .
+          destination: ./_site
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: ./_site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Adds an explicit GitHub Pages workflow using Node 24-backed actions.
- Replaces the legacy generated Pages build path that currently downloads `actions/checkout@v4` and `actions/upload-pages-artifact@v3`.
- Keeps the Jekyll build path aligned with GitHub Pages by using `actions/jekyll-build-pages@v1`.

## Why
The current Pages setting uses legacy branch deployment. Recent `pages-build-deployment` logs warn that Node 20 actions are deprecated because the generated build job uses `actions/checkout@v4` and `actions/upload-artifact@v4` through the older artifact chain.

After this PR merges, switch the repository Pages source from legacy branch deployment to GitHub Actions. Current API state is `build_type: legacy`, `source: main /`.

## Validation
- `bundle exec jekyll build --quiet`
- `ruby scripts/check_seo_crawl.rb --site-dir _site`
- `node tests/calculator-formulas.test.js`
- `for f in assets/js/analytics.js assets/js/calculators/*.js tests/calculator-formulas.test.js; do node --check "$f" || exit 1; done`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |path| YAML.load_file(path); puts "parsed #{path}" }'`
- `rg -n "node20|actions/checkout@v4|actions/upload-pages-artifact@v3|actions/upload-artifact@v4" .github || true`

Reference: GitHub Actions Node 20 deprecation warning from the latest Pages run, and GitHub changelog for Node 20 removal.