### PR TITLE
style: Soften landing page colors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -104,7 +104,7 @@ features                                  :
 # Theme Settings
 topbar_color                              : "#ffffff"
 topbar_transparency                       : 1
-topbar_title_color                        : "#171A1F"
+topbar_title_color                        : "#1D2228"
 
 cover_image                               : assets/product/report-builder-ipad.png
 cover_overlay_color                       : "#ffffff"
@@ -112,24 +112,24 @@ cover_overlay_transparency                : 0
 
 device_color                              : black                                     # Set to: blue, black, yellow, coral or white.
 
-body_background_color                     : "#F6F3EE"
+body_background_color                     : "#F6F7F4"
 
-link_color                                : "#E36F1E"
+link_color                                : "#A9571E"
 
-app_title_color                           : "#171A1F"
-app_price_color                           : "#4A5568"
-app_description_color                     : "#4A5568"
+app_title_color                           : "#1D2228"
+app_price_color                           : "#5F685C"
+app_description_color                     : "#5F685C"
 
-feature_title_color                       : "#171A1F"
-feature_text_color                        : "#4A5568"
+feature_title_color                       : "#1D2228"
+feature_text_color                        : "#5F685C"
 
-feature_icons_foreground_color            : "#E36F1E"
-feature_icons_background_color            : "#FFF3E8"
+feature_icons_foreground_color            : "#D97B18"
+feature_icons_background_color            : "#FFF4EA"
 
-social_icons_foreground_color             : "#4A5568"
-social_icons_background_color             : "#ECE7DE"
+social_icons_foreground_color             : "#5F685C"
+social_icons_background_color             : "#ECEFE8"
 
-footer_text_color                         : "#4A5568"
+footer_text_color                         : "#5F685C"
 
 
 

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -1,13 +1,13 @@
 $content-width: 1180px;
 $font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-$primary-text-color: #171a1f;
-$muted-text-color: #4a5568;
-$soft-border-color: #dfd8cf;
-$surface-color: #fffaf4;
+$primary-text-color: #1d2228;
+$muted-text-color: #5f685c;
+$soft-border-color: #e1e4dc;
+$surface-color: #fafbf8;
 $paper-color: #ffffff;
-$accent-soft-color: #fff3e8;
-$ink-soft-color: #2c3642;
-$drop-shadow: 0 22px 55px rgba(33, 28, 22, 0.12);
+$accent-soft-color: #fff4ea;
+$ink-soft-color: #3d443a;
+$drop-shadow: 0 18px 46px rgba(29, 34, 40, 0.1);
 
 html {
   font-size: 62.5%;

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -109,7 +109,7 @@ main {
   object-position: right center;
   opacity: 0.72;
   background: $paper-color;
-  box-shadow: 0 28px 80px rgba(33, 28, 22, 0.14);
+  box-shadow: 0 24px 64px rgba($primary-text-color, 0.12);
   transform: none;
 }
 
@@ -379,7 +379,7 @@ main {
   min-height: 88px;
   border-radius: 8px;
   background:
-    linear-gradient(135deg, rgba(227, 111, 30, 0.34), rgba(44, 54, 66, 0.16)),
+    linear-gradient(135deg, rgba($accent-color, 0.26), rgba($primary-text-color, 0.14)),
     $accent-soft-color;
 }
 
@@ -603,7 +603,7 @@ main {
 .calculator-error {
   min-height: 24px;
   margin-top: 14px;
-  color: #9b3516;
+  color: #8c3f12;
   font-size: 1.5rem;
   font-weight: 700;
 }


### PR DESCRIPTION
## Summary
- Align the landing theme with the app's FlexScheme.shark palette.
- Move the page background, borders, muted text, cards, and shadows toward the app's softer gray-green surfaces.
- Keep orange as a restrained accent while using a darker accessible link color.

## Validation
- `bundle exec jekyll build --quiet`
- `ruby scripts/check_seo_crawl.rb --site-dir _site`
- `node tests/calculator-formulas.test.js`
- `for f in assets/js/analytics.js assets/js/calculators/*.js tests/calculator-formulas.test.js; do node --check "$f" || exit 1; done`
- `git diff --check`
- Generated CSS color assertion confirmed the new palette is present, old landing palette is absent, and body text/link/error contrast ratios are at least 4.5:1.

Note: I did not start a local server. Playwright CLI could launch WebKit but blocked direct `file://` access, so verification used the generated `_site` output and CSS assertions.