### PR TITLE
feat: add Spanish SEO landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ Expected pass output:
 SEO crawl check passed for https://app.rehabestimator.app using local build _site
 - homepage: 200
 - robots.txt: 200, allows crawling, points to https://app.rehabestimator.app/sitemap.xml
-- sitemap.xml: 200 XML with 10 URLs and lastmod values
+- sitemap.xml: 200 XML with 19 URLs and lastmod values
 - sitemap coverage: homepage and calculator pages present
-- pages: 10 URLs returned 200, canonical matched, no noindex
+- localized pages: 4 English/Spanish hreflang pairs present
+- pages: 19 URLs returned 200, canonical matched, no noindex
 ```
 
 After deployment, the same crawl check can verify the live site:

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ app_icon                                  : assets/app-icon.png
 app_name                                  : Rehab Estimator
 app_price                                 : Free
 app_description                           : Create rehab estimates, attach photos, calculate deal numbers, and share client-ready PDF reports.
+app_description_es                        : Crea estimados de reparaciones, agrega fotos, calcula los números del proyecto y comparte reportes PDF listos para revisar.
 google_analytics_id                       : G-CW74KH0YSC
 
 enable_smart_app_banner                   : true                                      # Set to true to show a smart app banner at top of page on mobile devices.
@@ -23,13 +24,25 @@ sitemap_urls:
   - path: /
     lastmod: "2026-05-15"
     priority: 1.0
+  - path: /es/
+    lastmod: "2026-05-15"
+    priority: 0.9
   - path: /rehab-cost-calculator/
+    lastmod: "2026-05-15"
+    priority: 0.8
+  - path: /es/calculadora-costos-remodelacion/
     lastmod: "2026-05-15"
     priority: 0.8
   - path: /fix-and-flip-calculator/
     lastmod: "2026-05-15"
     priority: 0.8
+  - path: /es/calculadora-fix-and-flip/
+    lastmod: "2026-05-15"
+    priority: 0.8
   - path: /rental-cashflow-calculator/
+    lastmod: "2026-05-15"
+    priority: 0.8
+  - path: /es/calculadora-flujo-renta/
     lastmod: "2026-05-15"
     priority: 0.8
   - path: /kitchen-remodel-cost-estimator/
@@ -65,6 +78,16 @@ sitemap_urls:
   - path: /request_delete_data/
     lastmod: "2023-03-27"
     priority: 0.4
+
+localized_page_pairs:
+  - en: /
+    es: /es/
+  - en: /rehab-cost-calculator/
+    es: /es/calculadora-costos-remodelacion/
+  - en: /fix-and-flip-calculator/
+    es: /es/calculadora-fix-and-flip/
+  - en: /rental-cashflow-calculator/
+    es: /es/calculadora-flujo-renta/
 
 
 # Information About Yourself

--- a/_includes/calculator_tools/fix_flip.html
+++ b/_includes/calculator_tools/fix_flip.html
@@ -1,44 +1,80 @@
+{% assign calculator_locale = include.locale | default: page.lang %}
+{% if calculator_locale == "es" %}
+  {% assign tool_title = "Calculadora fix and flip" %}
+  {% assign tool_description = "Estima precio máximo de compra y utilidad proyectada con ARV, reparaciones, venta y tiempo de holding." %}
+  {% assign arv_label = "Valor después de reparar" %}
+  {% assign purchase_price_label = "Precio de compra" %}
+  {% assign desired_profit_label = "Utilidad deseada" %}
+  {% assign repair_cost_label = "Costo de reparaciones" %}
+  {% assign purchase_costs_label = "Costos de compra" %}
+  {% assign selling_costs_label = "Costos de venta" %}
+  {% assign monthly_holding_label = "Holding mensual" %}
+  {% assign holding_months_label = "Meses de holding" %}
+  {% assign commission_label = "Comisión de agente" %}
+  {% assign max_purchase_label = "Precio máximo de compra" %}
+  {% assign projected_profit_label = "Utilidad proyectada" %}
+  {% assign profit_margin_label = "Margen de utilidad" %}
+  {% assign breakdown_label = "Resumen de costos" %}
+  {% assign cta_copy = "Guarda los supuestos del proyecto junto al alcance de reparaciones, fotos y reporte PDF." %}
+{% else %}
+  {% assign tool_title = "Fix and Flip Calculator" %}
+  {% assign tool_description = "Estimate maximum purchase price and projected profit from ARV, repairs, selling costs, and hold time." %}
+  {% assign arv_label = "After repair value" %}
+  {% assign purchase_price_label = "Purchase price" %}
+  {% assign desired_profit_label = "Desired profit" %}
+  {% assign repair_cost_label = "Repair cost" %}
+  {% assign purchase_costs_label = "Purchase costs" %}
+  {% assign selling_costs_label = "Selling costs" %}
+  {% assign monthly_holding_label = "Holding cost per month" %}
+  {% assign holding_months_label = "Holding months" %}
+  {% assign commission_label = "Agent commission" %}
+  {% assign max_purchase_label = "Maximum purchase price" %}
+  {% assign projected_profit_label = "Projected profit" %}
+  {% assign profit_margin_label = "Profit margin" %}
+  {% assign breakdown_label = "Cost summary" %}
+  {% assign cta_copy = "Save the deal assumptions with the repair scope, photos, and PDF report in Rehab Estimator." %}
+{% endif %}
 <section class="calculator-tool" data-calculator="fix-flip">
   <div class="calculator-tool__header">
-    <h2>Fix and Flip Calculator</h2>
-    <p>Estimate maximum purchase price and projected profit from ARV, repairs, selling costs, and hold time.</p>
+    <h2>{{ tool_title }}</h2>
+    <p>{{ tool_description }}</p>
   </div>
 
   <form class="calculator-form">
     <label>
-      <span>After repair value</span>
+      <span>{{ arv_label }}</span>
       <input type="number" min="1" step="5000" value="350000" data-input="arv" inputmode="decimal">
     </label>
     <label>
-      <span>Purchase price</span>
+      <span>{{ purchase_price_label }}</span>
       <input type="number" min="0" step="5000" value="230000" data-input="purchasePrice" inputmode="decimal">
     </label>
     <label>
-      <span>Desired profit</span>
+      <span>{{ desired_profit_label }}</span>
       <input type="number" min="0" step="1000" value="40000" data-input="desiredProfit" inputmode="decimal">
     </label>
     <label>
-      <span>Repair cost</span>
+      <span>{{ repair_cost_label }}</span>
       <input type="number" min="0" step="1000" value="45000" data-input="repairCost" inputmode="decimal">
     </label>
     <label>
-      <span>Purchase costs</span>
+      <span>{{ purchase_costs_label }}</span>
       <input type="number" min="0" step="500" value="6000" data-input="purchaseCost" inputmode="decimal">
     </label>
     <label>
-      <span>Selling costs</span>
+      <span>{{ selling_costs_label }}</span>
       <input type="number" min="0" step="500" value="5000" data-input="saleCost" inputmode="decimal">
     </label>
     <label>
-      <span>Holding cost per month</span>
+      <span>{{ monthly_holding_label }}</span>
       <input type="number" min="0" step="100" value="2200" data-input="monthlyHoldingCost" inputmode="decimal">
     </label>
     <label>
-      <span>Holding months</span>
+      <span>{{ holding_months_label }}</span>
       <input type="number" min="0" step="1" value="5" data-input="holdingMonths" inputmode="decimal">
     </label>
     <label>
-      <span>Agent commission</span>
+      <span>{{ commission_label }}</span>
       <input type="number" min="0" max="12" step="0.25" value="6" data-input="commissionRate" inputmode="decimal">
     </label>
   </form>
@@ -47,26 +83,26 @@
 
   <div class="calculator-results" aria-live="polite">
     <div>
-      <span>Maximum purchase price</span>
+      <span>{{ max_purchase_label }}</span>
       <strong data-output="maxPurchasePrice">$0</strong>
     </div>
     <div>
-      <span>Projected profit</span>
+      <span>{{ projected_profit_label }}</span>
       <strong data-output="projectedProfit">$0</strong>
     </div>
     <div>
-      <span>Profit margin</span>
+      <span>{{ profit_margin_label }}</span>
       <strong data-output="profitMargin">0%</strong>
     </div>
   </div>
 
   <div class="calculator-breakdown">
-    <h3>Cost summary</h3>
+    <h3>{{ breakdown_label }}</h3>
     <dl data-output="breakdown"></dl>
   </div>
 
   <div class="calculator-tool__cta">
-    <p>Save the deal assumptions with the repair scope, photos, and PDF report in Rehab Estimator.</p>
+    <p>{{ cta_copy }}</p>
     {% include download_cta.html location="calculator_result" %}
   </div>
 </section>

--- a/_includes/calculator_tools/rehab_cost.html
+++ b/_includes/calculator_tools/rehab_cost.html
@@ -1,24 +1,54 @@
+{% assign calculator_locale = include.locale | default: page.lang %}
+{% if calculator_locale == "es" %}
+  {% assign tool_title = "Calculadora de costos de remodelación" %}
+  {% assign tool_description = "Estima un rango bajo y alto con pies cuadrados, nivel de remodelación y contingencia." %}
+  {% assign square_feet_label = "Pies cuadrados" %}
+  {% assign intensity_label = "Nivel de remodelación" %}
+  {% assign light_label = "Cosmética ligera" %}
+  {% assign medium_label = "Remodelación media" %}
+  {% assign heavy_label = "Remodelación pesada" %}
+  {% assign contingency_label = "Contingencia" %}
+  {% assign low_total_label = "Estimado bajo" %}
+  {% assign high_total_label = "Estimado alto" %}
+  {% assign contingency_added_label = "Contingencia agregada" %}
+  {% assign breakdown_label = "Rangos por categoría" %}
+  {% assign cta_copy = "Guarda el estimado por alcance, fotos, notas y reporte PDF en Rehab Estimator." %}
+{% else %}
+  {% assign tool_title = "Rehab Cost Calculator" %}
+  {% assign tool_description = "Estimate a low and high repair range from square footage, rehab intensity, and contingency." %}
+  {% assign square_feet_label = "Square footage" %}
+  {% assign intensity_label = "Rehab intensity" %}
+  {% assign light_label = "Light cosmetic" %}
+  {% assign medium_label = "Medium rehab" %}
+  {% assign heavy_label = "Heavy rehab" %}
+  {% assign contingency_label = "Contingency" %}
+  {% assign low_total_label = "Low estimate" %}
+  {% assign high_total_label = "High estimate" %}
+  {% assign contingency_added_label = "Contingency added" %}
+  {% assign breakdown_label = "Category ranges" %}
+  {% assign cta_copy = "Save the scoped estimate, photos, notes, and PDF report in Rehab Estimator." %}
+{% endif %}
 <section class="calculator-tool" data-calculator="rehab-cost">
   <div class="calculator-tool__header">
-    <h2>Rehab Cost Calculator</h2>
-    <p>Estimate a low and high repair range from square footage, rehab intensity, and contingency.</p>
+    <h2>{{ tool_title }}</h2>
+    <p>{{ tool_description }}</p>
   </div>
 
   <form class="calculator-form">
     <label>
-      <span>Square footage</span>
+      <span>{{ square_feet_label }}</span>
       <input type="number" min="1" step="50" value="1500" data-input="squareFeet" inputmode="decimal">
     </label>
     <label>
-      <span>Rehab intensity</span>
+      <span>{{ intensity_label }}</span>
       <select data-input="intensity">
-        <option value="light">Light cosmetic</option>
-        <option value="medium" selected>Medium rehab</option>
-        <option value="heavy">Heavy rehab</option>
+        <option value="light">{{ light_label }}</option>
+        <option value="medium" selected>{{ medium_label }}</option>
+        <option value="heavy">{{ heavy_label }}</option>
       </select>
     </label>
     <label>
-      <span>Contingency</span>
+      <span>{{ contingency_label }}</span>
       <input type="number" min="0" max="40" step="1" value="10" data-input="contingencyRate" inputmode="decimal">
     </label>
   </form>
@@ -27,26 +57,26 @@
 
   <div class="calculator-results" aria-live="polite">
     <div>
-      <span>Low estimate</span>
+      <span>{{ low_total_label }}</span>
       <strong data-output="lowTotal">$0</strong>
     </div>
     <div>
-      <span>High estimate</span>
+      <span>{{ high_total_label }}</span>
       <strong data-output="highTotal">$0</strong>
     </div>
     <div>
-      <span>Contingency added</span>
+      <span>{{ contingency_added_label }}</span>
       <strong data-output="contingency">$0</strong>
     </div>
   </div>
 
   <div class="calculator-breakdown">
-    <h3>Category ranges</h3>
+    <h3>{{ breakdown_label }}</h3>
     <dl data-output="breakdown"></dl>
   </div>
 
   <div class="calculator-tool__cta">
-    <p>Save the scoped estimate, photos, notes, and PDF report in Rehab Estimator.</p>
+    <p>{{ cta_copy }}</p>
     {% include download_cta.html location="calculator_result" %}
   </div>
 </section>

--- a/_includes/calculator_tools/rental_cashflow.html
+++ b/_includes/calculator_tools/rental_cashflow.html
@@ -1,60 +1,104 @@
+{% assign calculator_locale = include.locale | default: page.lang %}
+{% if calculator_locale == "es" %}
+  {% assign tool_title = "Calculadora de flujo de renta" %}
+  {% assign tool_description = "Estima flujo mensual, efectivo invertido y retorno con supuestos de remodelación y operación." %}
+  {% assign purchase_price_label = "Precio de compra" %}
+  {% assign rehab_cost_label = "Costo de reparaciones" %}
+  {% assign closing_cost_label = "Costos de cierre" %}
+  {% assign down_payment_label = "Pago inicial" %}
+  {% assign interest_rate_label = "Tasa de interés" %}
+  {% assign loan_years_label = "Años del préstamo" %}
+  {% assign monthly_rent_label = "Renta mensual" %}
+  {% assign vacancy_label = "Vacancia" %}
+  {% assign management_label = "Administración" %}
+  {% assign maintenance_label = "Mantenimiento" %}
+  {% assign annual_taxes_label = "Impuestos anuales" %}
+  {% assign annual_insurance_label = "Seguro anual" %}
+  {% assign misc_monthly_label = "Otros mensuales" %}
+  {% assign monthly_cashflow_label = "Flujo mensual" %}
+  {% assign cash_invested_label = "Efectivo invertido" %}
+  {% assign cash_return_label = "Retorno cash-on-cash" %}
+  {% assign breakdown_label = "Resumen de gastos mensuales" %}
+  {% assign cta_copy = "Guarda los supuestos de renta con fotos de reparaciones, notas y un estimado PDF." %}
+{% else %}
+  {% assign tool_title = "Rental Cashflow Calculator" %}
+  {% assign tool_description = "Estimate monthly cashflow, cash invested, and cash-on-cash return with rehab and operating assumptions." %}
+  {% assign purchase_price_label = "Purchase price" %}
+  {% assign rehab_cost_label = "Rehab cost" %}
+  {% assign closing_cost_label = "Closing cost" %}
+  {% assign down_payment_label = "Down payment" %}
+  {% assign interest_rate_label = "Interest rate" %}
+  {% assign loan_years_label = "Loan years" %}
+  {% assign monthly_rent_label = "Monthly rent" %}
+  {% assign vacancy_label = "Vacancy" %}
+  {% assign management_label = "Management" %}
+  {% assign maintenance_label = "Maintenance" %}
+  {% assign annual_taxes_label = "Annual taxes" %}
+  {% assign annual_insurance_label = "Annual insurance" %}
+  {% assign misc_monthly_label = "Misc monthly" %}
+  {% assign monthly_cashflow_label = "Monthly cashflow" %}
+  {% assign cash_invested_label = "Cash invested" %}
+  {% assign cash_return_label = "Cash-on-cash return" %}
+  {% assign breakdown_label = "Monthly expense summary" %}
+  {% assign cta_copy = "Save the rental assumptions with repair photos, notes, and a PDF estimate in Rehab Estimator." %}
+{% endif %}
 <section class="calculator-tool" data-calculator="rental-cashflow">
   <div class="calculator-tool__header">
-    <h2>Rental Cashflow Calculator</h2>
-    <p>Estimate monthly cashflow, cash invested, and cash-on-cash return with rehab and operating assumptions.</p>
+    <h2>{{ tool_title }}</h2>
+    <p>{{ tool_description }}</p>
   </div>
 
   <form class="calculator-form">
     <label>
-      <span>Purchase price</span>
+      <span>{{ purchase_price_label }}</span>
       <input type="number" min="1" step="5000" value="220000" data-input="purchasePrice" inputmode="decimal">
     </label>
     <label>
-      <span>Rehab cost</span>
+      <span>{{ rehab_cost_label }}</span>
       <input type="number" min="0" step="1000" value="30000" data-input="rehabCost" inputmode="decimal">
     </label>
     <label>
-      <span>Closing cost</span>
+      <span>{{ closing_cost_label }}</span>
       <input type="number" min="0" step="500" value="6000" data-input="closingCost" inputmode="decimal">
     </label>
     <label>
-      <span>Down payment</span>
+      <span>{{ down_payment_label }}</span>
       <input type="number" min="0" max="100" step="1" value="20" data-input="downPaymentRate" inputmode="decimal">
     </label>
     <label>
-      <span>Interest rate</span>
+      <span>{{ interest_rate_label }}</span>
       <input type="number" min="0" max="30" step="0.125" value="7" data-input="interestRate" inputmode="decimal">
     </label>
     <label>
-      <span>Loan years</span>
+      <span>{{ loan_years_label }}</span>
       <input type="number" min="1" max="40" step="1" value="30" data-input="loanYears" inputmode="decimal">
     </label>
     <label>
-      <span>Monthly rent</span>
+      <span>{{ monthly_rent_label }}</span>
       <input type="number" min="0" step="50" value="2400" data-input="rent" inputmode="decimal">
     </label>
     <label>
-      <span>Vacancy</span>
+      <span>{{ vacancy_label }}</span>
       <input type="number" min="0" max="100" step="1" value="5" data-input="vacancyRate" inputmode="decimal">
     </label>
     <label>
-      <span>Management</span>
+      <span>{{ management_label }}</span>
       <input type="number" min="0" max="100" step="1" value="8" data-input="managementRate" inputmode="decimal">
     </label>
     <label>
-      <span>Maintenance</span>
+      <span>{{ maintenance_label }}</span>
       <input type="number" min="0" max="100" step="1" value="5" data-input="maintenanceRate" inputmode="decimal">
     </label>
     <label>
-      <span>Annual taxes</span>
+      <span>{{ annual_taxes_label }}</span>
       <input type="number" min="0" step="100" value="3600" data-input="annualTaxes" inputmode="decimal">
     </label>
     <label>
-      <span>Annual insurance</span>
+      <span>{{ annual_insurance_label }}</span>
       <input type="number" min="0" step="100" value="1800" data-input="annualInsurance" inputmode="decimal">
     </label>
     <label>
-      <span>Misc monthly</span>
+      <span>{{ misc_monthly_label }}</span>
       <input type="number" min="0" step="25" value="75" data-input="miscMonthly" inputmode="decimal">
     </label>
   </form>
@@ -63,26 +107,26 @@
 
   <div class="calculator-results" aria-live="polite">
     <div>
-      <span>Monthly cashflow</span>
+      <span>{{ monthly_cashflow_label }}</span>
       <strong data-output="monthlyCashflow">$0</strong>
     </div>
     <div>
-      <span>Cash invested</span>
+      <span>{{ cash_invested_label }}</span>
       <strong data-output="cashInvested">$0</strong>
     </div>
     <div>
-      <span>Cash-on-cash return</span>
+      <span>{{ cash_return_label }}</span>
       <strong data-output="cashOnCashReturn">0%</strong>
     </div>
   </div>
 
   <div class="calculator-breakdown">
-    <h3>Monthly expense summary</h3>
+    <h3>{{ breakdown_label }}</h3>
     <dl data-output="breakdown"></dl>
   </div>
 
   <div class="calculator-tool__cta">
-    <p>Save the rental assumptions with repair photos, notes, and a PDF estimate in Rehab Estimator.</p>
+    <p>{{ cta_copy }}</p>
     {% include download_cta.html location="calculator_result" %}
   </div>
 </section>

--- a/_includes/download_cta.html
+++ b/_includes/download_cta.html
@@ -1,8 +1,14 @@
+{% assign app_store_label = "Download on the App Store" %}
+{% assign play_store_label = "Get it on Google Play" %}
+{% if page.lang == "es" %}
+  {% assign app_store_label = "Descargar en App Store" %}
+  {% assign play_store_label = "Disponible en Google Play" %}
+{% endif %}
 <div class="download-actions">
-  <a class="store-badge" href="{{ site.appstore_link }}" aria-label="Download on the App Store" data-analytics-event="app_store_cta_click" data-store="app_store" data-cta-location="{{ include.location | default: 'download_cta' }}">
-    <img src="{{ '/assets/appstore.png' | relative_url }}" alt="Download on the App Store" />
+  <a class="store-badge" href="{{ site.appstore_link }}" aria-label="{{ app_store_label }}" data-analytics-event="app_store_cta_click" data-store="app_store" data-cta-location="{{ include.location | default: 'download_cta' }}">
+    <img src="{{ '/assets/appstore.png' | relative_url }}" alt="{{ app_store_label }}" />
   </a>
-  <a class="store-badge" href="{{ site.playstore_link }}" aria-label="Get it on Google Play" data-analytics-event="play_store_cta_click" data-store="play_store" data-cta-location="{{ include.location | default: 'download_cta' }}">
-    <img src="{{ '/assets/playstore.png' | relative_url }}" alt="Get it on Google Play" />
+  <a class="store-badge" href="{{ site.playstore_link }}" aria-label="{{ play_store_label }}" data-analytics-event="play_store_cta_click" data-store="play_store" data-cta-location="{{ include.location | default: 'download_cta' }}">
+    <img src="{{ '/assets/playstore.png' | relative_url }}" alt="{{ play_store_label }}" />
   </a>
 </div>

--- a/_includes/faq_section.html
+++ b/_includes/faq_section.html
@@ -1,6 +1,10 @@
 {% if page.faqs %}
+{% assign faq_heading = "Frequently Asked Questions" %}
+{% if page.lang == "es" %}
+  {% assign faq_heading = "Preguntas frecuentes" %}
+{% endif %}
 <section class="faq-section">
-  <h2>Frequently Asked Questions</h2>
+  <h2>{{ faq_heading }}</h2>
   {% for faq in page.faqs %}
   <div class="faq-item">
     <h3>{{ faq.question }}</h3>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,33 +1,64 @@
+{% assign is_spanish = false %}
+{% if page.lang == "es" %}
+  {% assign is_spanish = true %}
+{% endif %}
 <footer class="site-footer">
   <div class="footer-brand">
     <img class="brand-icon" src="{{ site.app_icon | relative_url }}" alt="" />
     <div>
       <strong>{{ site.app_name }}</strong>
+      {% if is_spanish %}
+      <p>{{ site.app_description_es }}</p>
+      {% else %}
       <p>{{ site.app_description }}</p>
+      {% endif %}
     </div>
   </div>
 
   <div class="footer-columns">
     <div>
+      {% if is_spanish %}
+      <h2>Producto</h2>
+      <a href="{{ '/es/#product' | relative_url }}" target="_self">Funciones</a>
+      <a href="{{ '/es/#proof' | relative_url }}" target="_self">Capturas</a>
+      <a href="{{ '/es/#sample-report' | relative_url }}" target="_self">Reporte ejemplo</a>
+      <a href="{{ '/' | relative_url }}" target="_self">English</a>
+      {% else %}
       <h2>Product</h2>
       <a href="{{ '/#product' | relative_url }}" target="_self">Features</a>
       <a href="{{ '/#proof' | relative_url }}" target="_self">Screenshots</a>
       <a href="{{ '/#sample-report' | relative_url }}" target="_self">Sample report</a>
       <a href="{{ '/changelog/' | relative_url }}" target="_self">What's New</a>
+      <a href="{{ '/es/' | relative_url }}" target="_self">Español</a>
+      {% endif %}
     </div>
     <div>
+      {% if is_spanish %}
+      <h2>Calculadoras</h2>
+      <a href="{{ '/es/calculadora-costos-remodelacion/' | relative_url }}" target="_self">Calculadora de costos de remodelación</a>
+      <a href="{{ '/es/calculadora-fix-and-flip/' | relative_url }}" target="_self">Calculadora fix and flip</a>
+      <a href="{{ '/es/calculadora-flujo-renta/' | relative_url }}" target="_self">Calculadora de flujo de renta</a>
+      {% else %}
       <h2>Calculators</h2>
       <a href="{{ '/rehab-cost-calculator/' | relative_url }}" target="_self">Rehab cost calculator</a>
       <a href="{{ '/fix-and-flip-calculator/' | relative_url }}" target="_self">Fix and flip calculator</a>
       <a href="{{ '/rental-cashflow-calculator/' | relative_url }}" target="_self">Rental cashflow calculator</a>
       <a href="{{ '/kitchen-remodel-cost-estimator/' | relative_url }}" target="_self">Kitchen remodel cost estimator</a>
       <a href="{{ '/bathroom-remodel-cost-estimator/' | relative_url }}" target="_self">Bathroom remodel cost estimator</a>
+      {% endif %}
     </div>
     <div>
+      {% if is_spanish %}
+      <h2>Legal</h2>
+      <a href="{{ '/privacypolicy/' | relative_url }}" target="_self">Política de privacidad</a>
+      <a href="{{ '/terms_of_use/' | relative_url }}" target="_self">Términos de uso</a>
+      <a href="{{ '/request_delete_data/' | relative_url }}" target="_self">Solicitud para eliminar datos</a>
+      {% else %}
       <h2>Legal</h2>
       <a href="{{ '/privacypolicy/' | relative_url }}" target="_self">Privacy Policy</a>
       <a href="{{ '/terms_of_use/' | relative_url }}" target="_self">Terms of Use</a>
       <a href="{{ '/request_delete_data/' | relative_url }}" target="_self">Data Deletion Request</a>
+      {% endif %}
       {% if site.email_address %}
       <a href="mailto:{{ site.email_address }}">{{ site.email_address }}</a>
       {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,18 @@
   {% assign resolved_description = page.meta_description | default: site.app_description %}
   {% assign resolved_url = page.url | absolute_url %}
   {% assign resolved_image = '/assets/product/report-builder-ipad.png' | absolute_url %}
+  {% assign localized_en = "" %}
+  {% assign localized_es = "" %}
+  {% for localized_pair in site.localized_page_pairs %}
+    {% if localized_pair.en == page.url or localized_pair.es == page.url %}
+      {% assign localized_en = localized_pair.en %}
+      {% assign localized_es = localized_pair.es %}
+    {% endif %}
+  {% endfor %}
+  {% assign home_label = "Home" %}
+  {% if page.lang == "es" %}
+    {% assign home_label = "Inicio" %}
+  {% endif %}
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -11,11 +23,21 @@
   <meta name="description" content="{{ resolved_description }}" />
   <meta name="robots" content="index, follow, max-image-preview:large" />
   <link rel="canonical" href="{{ resolved_url }}" />
+  {% if localized_en != "" and localized_es != "" %}
+  <link rel="alternate" hreflang="en" href="{{ localized_en | absolute_url }}" />
+  <link rel="alternate" hreflang="es" href="{{ localized_es | absolute_url }}" />
+  <link rel="alternate" hreflang="x-default" href="{{ localized_en | absolute_url }}" />
+  {% endif %}
   <meta property="og:title" content="{{ resolved_title }}" />
   <meta property="og:description" content="{{ resolved_description }}" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ resolved_url }}" />
   <meta property="og:site_name" content="{{ site.app_name }}" />
+  {% if page.lang == "es" %}
+  <meta property="og:locale" content="es_US" />
+  {% else %}
+  <meta property="og:locale" content="en_US" />
+  {% endif %}
   <meta property="og:image" content="{{ resolved_image }}" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="{{ resolved_title }}" />
@@ -40,7 +62,7 @@
   </script>
   {% endif %}
 
-  {% if page.url == '/' %}
+  {% if page.url == '/' or page.url == '/es/' %}
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -56,7 +78,7 @@
       "applicationCategory": "BusinessApplication",
       "applicationSubCategory": "Rehab estimate calculator",
       "operatingSystem": "iOS, Android",
-      "description": {{ site.app_description | jsonify }},
+      "description": {{ resolved_description | jsonify }},
       "creator": {
         "@type": "Person",
         "name": {{ site.your_name | jsonify }},
@@ -81,7 +103,7 @@
     }
   </script>
   {% endif %}
-  {% unless page.url == '/' %}
+  {% unless page.url == '/' or page.url == '/es/' %}
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -90,7 +112,7 @@
         {
           "@type": "ListItem",
           "position": 1,
-          "name": "Home",
+          "name": {{ home_label | jsonify }},
           "item": {{ site.url | jsonify }}
         },
         {

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,12 +1,44 @@
+{% assign is_spanish = false %}
+{% if page.lang == "es" %}
+  {% assign is_spanish = true %}
+{% endif %}
+{% if is_spanish %}
+  {% assign home_url = "/es/" %}
+  {% assign product_url = "/es/#product" %}
+  {% assign proof_url = "/es/#proof" %}
+  {% assign calculators_url = "/es/calculadora-costos-remodelacion/" %}
+  {% assign product_label = "Producto" %}
+  {% assign proof_label = "Prueba" %}
+  {% assign calculators_label = "Calculadoras" %}
+  {% assign download_label = "Descargar" %}
+  {% assign nav_label = "Navegación principal" %}
+  {% assign language_url = "/" %}
+  {% assign language_label = "English" %}
+  {% assign brand_label = site.app_name | append: " inicio" %}
+{% else %}
+  {% assign home_url = "/" %}
+  {% assign product_url = "/#product" %}
+  {% assign proof_url = "/#proof" %}
+  {% assign calculators_url = "/rehab-cost-calculator/" %}
+  {% assign product_label = "Product" %}
+  {% assign proof_label = "Proof" %}
+  {% assign calculators_label = "Calculators" %}
+  {% assign download_label = "Download" %}
+  {% assign nav_label = "Primary navigation" %}
+  {% assign language_url = "/es/" %}
+  {% assign language_label = "Español" %}
+  {% assign brand_label = site.app_name | append: " home" %}
+{% endif %}
 <header class="site-header">
-  <a class="brand" href="{{ '/' | relative_url }}" target="_self" aria-label="{{ site.app_name }} home">
+  <a class="brand" href="{{ home_url | relative_url }}" target="_self" aria-label="{{ brand_label }}">
     <img class="brand-icon" src="{{ site.app_icon | relative_url }}" alt="" />
     <span>{{ site.app_name }}</span>
   </a>
-  <nav class="site-nav" aria-label="Primary navigation">
-    <a href="{{ '/#product' | relative_url }}" target="_self">Product</a>
-    <a href="{{ '/#proof' | relative_url }}" target="_self">Proof</a>
-    <a href="{{ '/rehab-cost-calculator/' | relative_url }}" target="_self">Calculators</a>
-    <a href="{{ site.appstore_link }}" class="nav-cta" data-analytics-event="app_store_cta_click" data-store="app_store" data-cta-location="header">Download</a>
+  <nav class="site-nav" aria-label="{{ nav_label }}">
+    <a href="{{ product_url | relative_url }}" target="_self">{{ product_label }}</a>
+    <a href="{{ proof_url | relative_url }}" target="_self">{{ proof_label }}</a>
+    <a href="{{ calculators_url | relative_url }}" target="_self">{{ calculators_label }}</a>
+    <a href="{{ language_url | relative_url }}" target="_self">{{ language_label }}</a>
+    <a href="{{ site.appstore_link }}" class="nav-cta" data-analytics-event="app_store_cta_click" data-store="app_store" data-cta-location="header">{{ download_label }}</a>
   </nav>
 </header>

--- a/_includes/related_calculators.html
+++ b/_includes/related_calculators.html
@@ -1,6 +1,10 @@
 {% if page.related_calculators %}
+{% assign related_heading = "Related Calculator Guides" %}
+{% if page.lang == "es" %}
+  {% assign related_heading = "Guías de calculadoras relacionadas" %}
+{% endif %}
 <section class="related-calculators">
-  <h2>Related Calculator Guides</h2>
+  <h2>{{ related_heading }}</h2>
   <ul>
     {% for related_page in page.related_calculators %}
     <li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="en-us">
+{% assign html_lang = page.lang | default: "en-us" %}
+<html lang="{{ html_lang }}">
 
 {% include head.html %}
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,8 @@
 ---
 
 <!DOCTYPE html>
-<html lang="en-us">
+{% assign html_lang = page.lang | default: "en-us" %}
+<html lang="{{ html_lang }}">
 
 {% include head.html %}
 

--- a/_layouts/spanish_home.html
+++ b/_layouts/spanish_home.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+{% assign html_lang = page.lang | default: "es" %}
+<html lang="{{ html_lang }}">
+
+{% include head.html %}
+
+<body>
+  {% include header.html %}
+
+  <main>
+    <section class="hero">
+      <div class="hero-media" aria-hidden="true">
+        <img src="{{ '/assets/product/report-builder-ipad.png' | relative_url }}" alt="" />
+      </div>
+      <div class="hero-content">
+        <p class="eyebrow">App de estimados para remodelación, inversionistas y contratistas</p>
+        <h1>Rehab Estimator</h1>
+        <p class="hero-copy">
+          Crea estimados de reparaciones, agrega fotos, calcula los números del proyecto y comparte un reporte PDF desde el recorrido de la propiedad.
+        </p>
+        {% include download_cta.html %}
+        <div class="hero-proof" aria-label="Puntos principales del producto">
+          <span>Rangos de costo</span>
+          <span>Notas con fotos</span>
+          <span>Reporte PDF</span>
+          <span>iOS y Android</span>
+        </div>
+      </div>
+    </section>
+
+    <section id="product" class="section product-section">
+      <div class="section-heading">
+        <p class="eyebrow">Hecho para decisiones en campo</p>
+        <h2>Del recorrido a una cotización revisable en un solo flujo.</h2>
+      </div>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <span class="feature-index">01</span>
+          <h3>Estimados por alcance</h3>
+          <p>Organiza reparaciones por interior, exterior y trabajo general con cantidades, rangos y notas.</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-index">02</span>
+          <h3>Plantillas de trabajo</h3>
+          <p>Empieza con partidas comunes y ajusta materiales, mano de obra y prioridades según la propiedad.</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-index">03</span>
+          <h3>Reportes con fotos</h3>
+          <p>Adjunta fotos del sitio y comparte un PDF claro con socios, contratistas o clientes.</p>
+        </article>
+        <article class="feature-card">
+          <span class="feature-index">04</span>
+          <h3>Calculadoras del proyecto</h3>
+          <p>Revisa costos de remodelación, fix and flip y flujo de renta desde la misma información.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="proof" class="section proof-section">
+      <div class="proof-copy">
+        <p class="eyebrow">Prueba del producto</p>
+        <h2>Usa los mismos datos en reportes, calculadoras y biblioteca de trabajos.</h2>
+        <p>
+          Rehab Estimator mantiene partidas, cantidades, fotos y números del proyecto en una sola superficie para revisar el estimado antes de compartirlo.
+        </p>
+      </div>
+      <div class="screenshot-grid" aria-label="Capturas de la app">
+        <figure class="screenshot tall">
+          <img src="{{ '/assets/product/report-overview-mobile.png' | relative_url }}" alt="Resumen móvil de Rehab Estimator con partidas y total estimado" />
+        </figure>
+        <figure class="screenshot">
+          <img src="{{ '/assets/product/calculator-ipad.png' | relative_url }}" alt="Pantalla de calculadora de Rehab Estimator en iPad" />
+        </figure>
+      </div>
+    </section>
+
+    <section id="sample-report" class="section report-section">
+      <div class="section-heading">
+        <p class="eyebrow">Vista de reporte</p>
+        <h2>Convierte un estimado de trabajo en un PDF listo para revisar.</h2>
+      </div>
+      <div class="report-preview">
+        <div class="report-sheet">
+          <div class="report-head">
+            <span>Estimado de remodelación</span>
+            <strong>$28,100 a $49,200</strong>
+          </div>
+          <div class="report-property">
+            <p>123 Calle Demo</p>
+            <p>Propiedad de 1,850 sqft</p>
+          </div>
+          <div class="report-table" role="table" aria-label="Tabla de costos de reporte ejemplo">
+            <div role="row">
+              <span role="cell">Reemplazo de techo</span>
+              <strong role="cell">$9,200 a $14,600</strong>
+            </div>
+            <div role="row">
+              <span role="cell">Gabinetes y cubiertas</span>
+              <strong role="cell">$11,400 a $20,700</strong>
+            </div>
+            <div role="row">
+              <span role="cell">Pintura interior</span>
+              <strong role="cell">$2,800 a $5,200</strong>
+            </div>
+          </div>
+          <div class="photo-strip" aria-label="Espacios para fotos adjuntas">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        </div>
+        <div class="report-points">
+          <h3>Qué lleva el PDF</h3>
+          <ul>
+            <li>Categorías de alcance y rangos de costo por partida.</li>
+            <li>Datos de la propiedad desde el reporte.</li>
+            <li>Fotos y notas para revisión con contratistas o socios.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section seo-section">
+      <div class="section-heading">
+        <p class="eyebrow">Páginas de estimado</p>
+        <h2>Calculadoras para búsquedas comunes de remodelación.</h2>
+      </div>
+      <div class="seo-grid">
+        <a href="{{ '/es/calculadora-costos-remodelacion/' | relative_url }}" target="_self">
+          <span>Calculadora de costos de remodelación</span>
+          <p>Planea un presupuesto por cuarto, categoría, materiales y mano de obra.</p>
+        </a>
+        <a href="{{ '/es/calculadora-fix-and-flip/' | relative_url }}" target="_self">
+          <span>Calculadora fix and flip</span>
+          <p>Compara compra, reparaciones, holding, venta, ARV y utilidad.</p>
+        </a>
+        <a href="{{ '/es/calculadora-flujo-renta/' | relative_url }}" target="_self">
+          <span>Calculadora de flujo de renta</span>
+          <p>Estima renta mensual, financiamiento, vacancia, gastos y flujo neto.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="final-cta">
+      <div>
+        <p class="eyebrow">Empieza desde la propiedad</p>
+        <h2>Arma el estimado donde aparecen las preguntas.</h2>
+      </div>
+      {% include download_cta.html %}
+    </section>
+  </main>
+
+  {% include footer.html %}
+  <script src="{{ '/assets/js/analytics.js' | relative_url }}" defer></script>
+</body>
+</html>

--- a/_pages/es.md
+++ b/_pages/es.md
@@ -1,0 +1,9 @@
+---
+layout: spanish_home
+lang: es
+title: Rehab Estimator en Español
+seo_title: Rehab Estimator en Español | Estimados de remodelación y reportes PDF
+meta_description: Crea estimados de reparaciones, agrega fotos, calcula números del proyecto y comparte reportes PDF desde el recorrido de la propiedad.
+include_in_header: false
+permalink: /es/
+---

--- a/_pages/es/calculadora-costos-remodelacion.md
+++ b/_pages/es/calculadora-costos-remodelacion.md
@@ -1,0 +1,76 @@
+---
+layout: page
+lang: es
+title: Calculadora de Costos de Remodelación
+seo_title: Calculadora de Costos de Remodelación | Rehab Estimator
+meta_description: Estima costos de remodelación por pies cuadrados, nivel de trabajo, contingencia, materiales, mano de obra y rango bajo a alto.
+include_in_header: false
+permalink: /es/calculadora-costos-remodelacion/
+scripts:
+  - /assets/js/calculators/formulas.js
+  - /assets/js/calculators/ui.js
+  - /assets/js/calculators/rehab-cost.js
+faqs:
+  - question: ¿Qué debe incluir una calculadora de costos de remodelación?
+    answer: Debe incluir pies cuadrados, nivel de reparación, materiales, mano de obra, contingencia, fotos y notas que expliquen por qué cada partida está en el estimado.
+  - question: ¿Un estimado de reparaciones es igual a una cotización de contratista?
+    answer: No. El estimado ayuda a planear una oferta, presupuesto o alcance inicial. La cotización del contratista debe llegar después de revisar la propiedad, materiales y medidas reales.
+  - question: ¿Por qué usar un rango bajo y alto?
+    answer: El rango muestra la diferencia entre un escenario limpio y uno conservador cuando todavía pueden cambiar medidas, daños ocultos, precios de materiales o mano de obra.
+related_calculators:
+  - title: Calculadora fix and flip
+    url: /es/calculadora-fix-and-flip/
+    description: Usa el presupuesto de reparaciones dentro del precio de compra, ARV, costos de venta y utilidad.
+  - title: Calculadora de flujo de renta
+    url: /es/calculadora-flujo-renta/
+    description: Revisa cómo las reparaciones afectan efectivo invertido, renta lista y flujo mensual.
+  - title: Rehab cost calculator
+    url: /rehab-cost-calculator/
+    description: Ver la versión en inglés de esta guía.
+---
+
+<div class="page-hero">
+  <p class="eyebrow">Calculadora de costos de remodelación</p>
+  <h1>Arma un estimado de reparaciones antes de hacer una oferta.</h1>
+  <p>Usa pies cuadrados, nivel de remodelación y contingencia para crear un rango bajo y alto que puedas revisar con fotos, notas y alcance de trabajo.</p>
+</div>
+
+{% include calculator_tools/rehab_cost.html locale="es" %}
+
+## Qué capturar durante el recorrido
+
+Un buen estimado empieza con la condición real de la propiedad. Recorre cada área, separa reparaciones visibles de supuestos y anota el oficio, cantidad, rango de costo y nivel de confianza para cada partida.
+
+Mantén las fotos junto a las partidas que explican. Una nota como "reemplazar gabinetes bajos por daño de agua" es más útil cuando la foto, cantidad y rango quedan conectados al mismo elemento.
+
+## Categorías comunes para presupuestar
+
+- Interior: demolición, framing, sheetrock, piso, pintura, gabinetes, cubiertas, plomería, electricidad y HVAC.
+- Exterior: techo, siding, canaletas, concreto, garage, paisaje, cimientos y pintura exterior.
+- Trabajo general: permisos, limpieza, tratamiento de termitas, moho y partidas de proyecto.
+- Contingencia: daños ocultos, cambios de precio, medidas incompletas y ajustes después de revisar con contratistas.
+
+## Cómo defender el estimado
+
+Empieza con partidas claras y usa rangos cuando el precio dependa de medidas, materiales o mano de obra local. El número bajo representa una versión limpia del trabajo. El número alto ayuda a revisar el caso conservador antes de comprar o aprobar el proyecto.
+
+| Entrada del estimado | Por qué importa |
+| --- | --- |
+| Categoría de alcance | Evita mezclar interior, exterior y trabajo general. |
+| Cantidad | Reduce supuestos amplios aplicados a toda la propiedad. |
+| Costo bajo y alto | Muestra la diferencia entre escenario optimista y conservador. |
+| Fotos y notas | Explica la razón de cada partida cuando se comparte el reporte. |
+
+## Cuándo actualizarlo
+
+Actualiza el estimado después de medir áreas, recibir comentarios de contratistas, encontrar daños ocultos o cambiar el nivel de acabados. El presupuesto debe pasar de un rango rápido a un alcance más preciso conforme el proyecto se acerca a una decisión.
+
+{% include related_calculators.html %}
+
+{% include faq_section.html %}
+
+<div class="page-cta">
+  <h2>Crea el estimado en la app.</h2>
+  <p>Descarga Rehab Estimator para guardar reparaciones, fotos, notas y exportar un reporte PDF.</p>
+  {% include download_cta.html %}
+</div>

--- a/_pages/es/calculadora-fix-and-flip.md
+++ b/_pages/es/calculadora-fix-and-flip.md
@@ -1,0 +1,75 @@
+---
+layout: page
+lang: es
+title: Calculadora Fix and Flip
+seo_title: Calculadora Fix and Flip con Costos de Remodelación | Rehab Estimator
+meta_description: Calcula utilidad de un fix and flip con precio de compra, ARV, reparaciones, holding, venta, financiamiento y contingencia.
+include_in_header: false
+permalink: /es/calculadora-fix-and-flip/
+scripts:
+  - /assets/js/calculators/formulas.js
+  - /assets/js/calculators/ui.js
+  - /assets/js/calculators/fix-flip.js
+faqs:
+  - question: ¿Qué números debe usar una calculadora fix and flip?
+    answer: Debe incluir precio de compra, ARV, costo de reparaciones, costos de cierre, holding, venta, financiamiento, contingencia y utilidad esperada.
+  - question: ¿Cómo se deben manejar las reparaciones en un flip?
+    answer: El costo de reparaciones debe venir de un alcance revisable, no de un porcentaje genérico. Separa precios confirmados de contratistas, materiales pendientes y contingencia.
+  - question: ¿Qué margen de utilidad es bueno en un flip?
+    answer: Depende del riesgo, financiamiento, tiempo, mercado y confianza en el ARV. Muchos inversionistas revisan primero un caso conservador para ver si un cambio pequeño elimina la utilidad.
+related_calculators:
+  - title: Calculadora de costos de remodelación
+    url: /es/calculadora-costos-remodelacion/
+    description: Crea el presupuesto de reparaciones que alimenta el análisis del flip.
+  - title: Calculadora de flujo de renta
+    url: /es/calculadora-flujo-renta/
+    description: Compara si mantener la propiedad en renta compite con venderla después de reparar.
+  - title: Fix and flip calculator
+    url: /fix-and-flip-calculator/
+    description: Ver la versión en inglés de esta guía.
+---
+
+<div class="page-hero">
+  <p class="eyebrow">Calculadora fix and flip</p>
+  <h1>Revisa un flip con reparaciones, venta, holding y utilidad.</h1>
+  <p>Conecta el estimado de remodelación con los números del proyecto para que un ARV fuerte no esconda un presupuesto débil.</p>
+</div>
+
+{% include calculator_tools/fix_flip.html locale="es" %}
+
+## Qué calcular antes de hacer una oferta
+
+Un flip necesita espacio para compra, costos de cierre, reparaciones, tiempo, venta y utilidad. El costo de remodelación suele ser el riesgo más visible, pero el tiempo de holding y el ARV también pueden mover el resultado rápido.
+
+Antes de mandar una oferta, revisa el caso conservador: reparación alta, venta más lenta, costos de venta completos y una contingencia real. Si la utilidad desaparece en ese escenario, el precio de compra necesita cambiar.
+
+## Entradas principales del análisis
+
+| Entrada | Qué revisar |
+| --- | --- |
+| Precio de compra | Incluye cargos, closing costs y cualquier crédito del vendedor. |
+| ARV | Usa comparables realistas, no la mejor venta del vecindario. |
+| Costo de reparaciones | Conéctalo a partidas, fotos, materiales y mano de obra. |
+| Holding | Incluye pagos de préstamo, utilidades, impuestos, seguro y riesgo de retraso. |
+| Costos de venta | Incluye comisiones, cierre, staging, concesiones y limpieza. |
+| Contingencia | Reserva para errores de alcance, precios y calendario. |
+
+## Cómo cambia el deal cuando cambia el alcance
+
+Un flip puede parecer rentable hasta que el alcance pasa de cosmético a trabajo de sistemas. Techo, HVAC, plomería, electricidad, cimientos y cambios de distribución deben revisarse por separado porque afectan tanto presupuesto como tiempo.
+
+Si el rango alto de reparaciones mata la utilidad, la oferta tiene que bajar o el proyecto debe esperar más evidencia.
+
+## Flujo práctico
+
+Crea primero el reporte de propiedad, agrega partidas principales y luego usa la calculadora fix and flip para probar compra, ARV y costos. Actualiza el reporte cuando lleguen cotizaciones de contratistas y exporta un PDF para revisión.
+
+{% include related_calculators.html %}
+
+{% include faq_section.html %}
+
+<div class="page-cta">
+  <h2>Revisa el presupuesto y la utilidad juntos.</h2>
+  <p>Descarga Rehab Estimator para estimados, calculadoras, fotos y reportes PDF.</p>
+  {% include download_cta.html %}
+</div>

--- a/_pages/es/calculadora-flujo-renta.md
+++ b/_pages/es/calculadora-flujo-renta.md
@@ -1,0 +1,73 @@
+---
+layout: page
+lang: es
+title: Calculadora de Flujo de Renta
+seo_title: Calculadora de Flujo de Renta con Reparaciones | Rehab Estimator
+meta_description: Estima flujo mensual de renta con compra, préstamo, vacancia, impuestos, seguro, mantenimiento, administración y costo de reparaciones.
+include_in_header: false
+permalink: /es/calculadora-flujo-renta/
+scripts:
+  - /assets/js/calculators/formulas.js
+  - /assets/js/calculators/ui.js
+  - /assets/js/calculators/rental-cashflow.js
+faqs:
+  - question: ¿Qué gastos debe incluir una calculadora de flujo de renta?
+    answer: Debe incluir renta, pago del préstamo, impuestos, seguro, vacancia, mantenimiento, administración, gastos del dueño, reservas y reparaciones necesarias antes de rentar.
+  - question: ¿Las reparaciones van dentro del flujo mensual?
+    answer: Las reparaciones iniciales normalmente pertenecen al efectivo invertido y retorno cash-on-cash. Mantenimiento y reservas sí deben aparecer en el flujo mensual.
+  - question: ¿Por qué una propiedad con buena renta puede ser un mal deal?
+    answer: Reparaciones altas, vacancia, deuda, seguro, impuestos, administración o demora para rentar pueden reducir el flujo real aunque la renta bruta parezca fuerte.
+related_calculators:
+  - title: Calculadora de costos de remodelación
+    url: /es/calculadora-costos-remodelacion/
+    description: Estima las reparaciones antes de confiar en la fecha de renta lista.
+  - title: Calculadora fix and flip
+    url: /es/calculadora-fix-and-flip/
+    description: Compara mantener la propiedad en renta contra vender después de reparar.
+  - title: Rental cashflow calculator
+    url: /rental-cashflow-calculator/
+    description: Ver la versión en inglés de esta guía.
+---
+
+<div class="page-hero">
+  <p class="eyebrow">Calculadora de flujo de renta</p>
+  <h1>Revisa si una renta todavía funciona después de las reparaciones.</h1>
+  <p>Modela ingreso, gastos, deuda, vacancia, reservas y costo de remodelación para saber si la propiedad realmente queda lista para rentar.</p>
+</div>
+
+{% include calculator_tools/rental_cashflow.html locale="es" %}
+
+## Qué revisar antes de comprar
+
+Una renta puede verse fuerte cuando solo miras el ingreso bruto. El análisis debe incluir gastos recurrentes, efectivo necesario para dejar la unidad lista y el tiempo antes de que empiece la renta.
+
+Las reparaciones afectan el efectivo invertido, reservas, deuda y primer mes disponible para inquilino. Por eso conviene tener el estimado de reparaciones junto a la calculadora de renta.
+
+## Entradas que conviene separar
+
+| Entrada | Cómo usarla |
+| --- | --- |
+| Renta mensual | Basarla en listados y rentas cerradas cercanas. |
+| Vacancia | Reducir ingreso por rotación y tiempo de colocación. |
+| Deuda | Incluir principal e interés si hay financiamiento. |
+| Impuestos y seguro | Usar números de la propiedad cuando estén disponibles. |
+| Mantenimiento y reservas | Planear reparaciones recurrentes y partidas grandes futuras. |
+| Remodelación inicial | Medir el efectivo necesario antes de producir renta. |
+
+## Qué hacer cuando el flujo es delgado
+
+Si el deal solo funciona con reparaciones bajas, renta completa y cero retrasos, revisa el caso conservador. Sube vacancia, sube el presupuesto de reparaciones e incluye reservas. Si todavía funciona, el proyecto es más fácil de defender.
+
+## Flujo de campo
+
+Captura los datos de la propiedad, agrega reparaciones por alcance, adjunta fotos y luego corre la calculadora de flujo de renta. Ajusta el estimado cuando lleguen cotizaciones y exporta un PDF para revisar con socios o contratistas.
+
+{% include related_calculators.html %}
+
+{% include faq_section.html %}
+
+<div class="page-cta">
+  <h2>Estima las reparaciones antes de confiar en la renta.</h2>
+  <p>Descarga Rehab Estimator para reportes, calculadoras de renta y exportación PDF.</p>
+  {% include download_cta.html %}
+</div>

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -9,8 +9,11 @@
 
   function calculatorNameFromPath(path) {
     if (path.includes("rehab-cost-calculator")) return "rehab_cost";
+    if (path.includes("calculadora-costos-remodelacion")) return "rehab_cost";
     if (path.includes("fix-and-flip-calculator")) return "fix_and_flip";
+    if (path.includes("calculadora-fix-and-flip")) return "fix_and_flip";
     if (path.includes("rental-cashflow-calculator")) return "rental_cashflow";
+    if (path.includes("calculadora-flujo-renta")) return "rental_cashflow";
     return "";
   }
 

--- a/assets/js/calculators/fix-flip.js
+++ b/assets/js/calculators/fix-flip.js
@@ -6,6 +6,19 @@
   const container = document.querySelector('[data-calculator="fix-flip"]');
   if (!container || !formulas || !ui) return;
 
+  const isSpanish = document.documentElement.lang === "es";
+  const breakdownLabels = isSpanish ? {
+    holdingCost: "Costo de holding",
+    commission: "Comisión de agente",
+    nonPurchaseCost: "Costos fuera de compra",
+    totalProjectCost: "Costo total del proyecto"
+  } : {
+    holdingCost: "Holding cost",
+    commission: "Agent commission",
+    nonPurchaseCost: "Non-purchase costs",
+    totalProjectCost: "Total project cost"
+  };
+
   ui.bindCalculator(container, () => {
     const result = formulas.fixAndFlip({
       arv: ui.readNumber(container, "arv"),
@@ -23,10 +36,10 @@
     ui.setText(container, "projectedProfit", ui.formatCurrency(result.projectedProfit));
     ui.setText(container, "profitMargin", ui.formatPercent(result.profitMargin));
     ui.renderBreakdown(container, [
-      { label: "Holding cost", value: ui.formatCurrency(result.holdingCost) },
-      { label: "Agent commission", value: ui.formatCurrency(result.commission) },
-      { label: "Non-purchase costs", value: ui.formatCurrency(result.nonPurchaseCost) },
-      { label: "Total project cost", value: ui.formatCurrency(result.totalProjectCost) }
+      { label: breakdownLabels.holdingCost, value: ui.formatCurrency(result.holdingCost) },
+      { label: breakdownLabels.commission, value: ui.formatCurrency(result.commission) },
+      { label: breakdownLabels.nonPurchaseCost, value: ui.formatCurrency(result.nonPurchaseCost) },
+      { label: breakdownLabels.totalProjectCost, value: ui.formatCurrency(result.totalProjectCost) }
     ]);
     if (window.RehabAnalytics) {
       window.RehabAnalytics.trackCalculatorResult("fix_and_flip");

--- a/assets/js/calculators/rehab-cost.js
+++ b/assets/js/calculators/rehab-cost.js
@@ -6,6 +6,15 @@
   const container = document.querySelector('[data-calculator="rehab-cost"]');
   if (!container || !formulas || !ui) return;
 
+  const isSpanish = document.documentElement.lang === "es";
+  const labels = isSpanish ? {
+    Interior: "Interior",
+    Exterior: "Exterior",
+    Systems: "Sistemas",
+    General: "General"
+  } : {};
+  const rangeWord = isSpanish ? " a " : " to ";
+
   ui.bindCalculator(container, () => {
     const result = formulas.rehabCost({
       squareFeet: ui.readNumber(container, "squareFeet"),
@@ -17,8 +26,8 @@
     ui.setText(container, "highTotal", ui.formatCurrency(result.highTotal));
     ui.setText(container, "contingency", ui.formatCurrency(result.contingency));
     ui.renderBreakdown(container, result.breakdown.map((row) => ({
-      label: row.label,
-      value: `${ui.formatCurrency(row.low)} to ${ui.formatCurrency(row.high)}`
+      label: labels[row.label] || row.label,
+      value: `${ui.formatCurrency(row.low)}${rangeWord}${ui.formatCurrency(row.high)}`
     })));
     if (window.RehabAnalytics) {
       window.RehabAnalytics.trackCalculatorResult("rehab_cost");

--- a/assets/js/calculators/rental-cashflow.js
+++ b/assets/js/calculators/rental-cashflow.js
@@ -6,6 +6,23 @@
   const container = document.querySelector('[data-calculator="rental-cashflow"]');
   if (!container || !formulas || !ui) return;
 
+  const isSpanish = document.documentElement.lang === "es";
+  const breakdownLabels = isSpanish ? {
+    loanPayment: "Pago del préstamo",
+    vacancy: "Vacancia",
+    management: "Administración",
+    maintenance: "Mantenimiento",
+    taxesAndInsurance: "Impuestos y seguro",
+    operatingExpenses: "Gastos operativos"
+  } : {
+    loanPayment: "Loan payment",
+    vacancy: "Vacancy",
+    management: "Management",
+    maintenance: "Maintenance",
+    taxesAndInsurance: "Taxes and insurance",
+    operatingExpenses: "Operating expenses"
+  };
+
   ui.bindCalculator(container, () => {
     const result = formulas.rentalCashflow({
       purchasePrice: ui.readNumber(container, "purchasePrice"),
@@ -27,12 +44,12 @@
     ui.setText(container, "cashInvested", ui.formatCurrency(result.cashInvested));
     ui.setText(container, "cashOnCashReturn", ui.formatPercent(result.cashOnCashReturn));
     ui.renderBreakdown(container, [
-      { label: "Loan payment", value: ui.formatCurrency(result.loanPayment) },
-      { label: "Vacancy", value: ui.formatCurrency(result.vacancy) },
-      { label: "Management", value: ui.formatCurrency(result.management) },
-      { label: "Maintenance", value: ui.formatCurrency(result.maintenance) },
-      { label: "Taxes and insurance", value: ui.formatCurrency(result.taxes + result.insurance) },
-      { label: "Operating expenses", value: ui.formatCurrency(result.operatingExpenses) }
+      { label: breakdownLabels.loanPayment, value: ui.formatCurrency(result.loanPayment) },
+      { label: breakdownLabels.vacancy, value: ui.formatCurrency(result.vacancy) },
+      { label: breakdownLabels.management, value: ui.formatCurrency(result.management) },
+      { label: breakdownLabels.maintenance, value: ui.formatCurrency(result.maintenance) },
+      { label: breakdownLabels.taxesAndInsurance, value: ui.formatCurrency(result.taxes + result.insurance) },
+      { label: breakdownLabels.operatingExpenses, value: ui.formatCurrency(result.operatingExpenses) }
     ]);
     if (window.RehabAnalytics) {
       window.RehabAnalytics.trackCalculatorResult("rental_cashflow");

--- a/docs/seo-monitoring-runbook.md
+++ b/docs/seo-monitoring-runbook.md
@@ -16,7 +16,8 @@ Recorded from Google Search Console on May 15, 2026:
 - Sitemap: `https://app.rehabestimator.app/sitemap.xml`
 - Sitemap status after submission: `Success`
 - Sitemap last read: May 15, 2026
-- Sitemap discovered pages: 10
+- Sitemap discovered pages before Spanish launch: 10
+- Expected sitemap pages after Spanish launch: 19
 
 ## Weekly Check
 
@@ -42,11 +43,15 @@ Run this check once per week after sitemap or calculator page changes deploy.
    - Top queries
    - Top pages
 5. Compare calculator pages:
+   - `/es/`
    - `/rehab-cost-calculator/`
    - `/fix-and-flip-calculator/`
    - `/rental-cashflow-calculator/`
    - `/kitchen-remodel-cost-estimator/`
    - `/bathroom-remodel-cost-estimator/`
+   - `/es/calculadora-costos-remodelacion/`
+   - `/es/calculadora-fix-and-flip/`
+   - `/es/calculadora-flujo-renta/`
 6. Record changes in the active SEO issue or a dated note in this file.
 
 ## GA Events

--- a/scripts/check_seo_crawl.rb
+++ b/scripts/check_seo_crawl.rb
@@ -125,6 +125,21 @@ def canonical_href(html)
   nil
 end
 
+def html_lang(html)
+  match = html.match(/<html\b[^>]*\blang=["']([^"']+)["']/i)
+  match && match[1]
+end
+
+def hreflang_links(html)
+  html.scan(/<link\b[^>]*>/i).each_with_object({}) do |tag, links|
+    next unless tag.match?(/\brel=["'][^"']*\balternate\b[^"']*["']/i)
+
+    lang = tag.match(/\bhreflang=["']([^"']+)["']/i)&.[](1)
+    href = tag.match(/\bhref=["']([^"']+)["']/i)&.[](1)
+    links[lang] = href if lang && href
+  end
+end
+
 def noindex?(html)
   html.scan(/<meta\b[^>]*>/i).any? do |tag|
     tag.match?(/\bname=["']robots["']/i) && tag.match?(/\bcontent=["'][^"']*\bnoindex\b/i)
@@ -134,8 +149,13 @@ end
 config = YAML.load_file(options[:config])
 base_url = normalize_base_url(options[:base_url] || ENV["SEO_BASE_URL"] || config.fetch("url"))
 sitemap_config = config.fetch("sitemap_urls")
+localized_page_pairs = config.fetch("localized_page_pairs") { fail!("_config.yml is missing localized_page_pairs") }
+fail!("_config.yml localized_page_pairs is empty") if localized_page_pairs.empty?
 expected_urls = sitemap_config.map { |entry| absolute_url(base_url, entry.fetch("path")) }
 calculator_urls = expected_urls.select { |url| url.include?("calculator") || url.include?("estimator") }
+localized_urls = localized_page_pairs.flat_map do |pair|
+  [absolute_url(base_url, pair.fetch("en")), absolute_url(base_url, pair.fetch("es"))]
+end
 
 homepage = fetch(absolute_url(base_url, "/"), options)
 assert_200!(homepage, "homepage")
@@ -160,6 +180,9 @@ fail!("sitemap.xml is missing calculator URLs: #{missing_calculators.join(", ")}
 missing_config_urls = expected_urls - locs
 fail!("sitemap.xml is missing configured URLs: #{missing_config_urls.join(", ")}") unless missing_config_urls.empty?
 
+missing_localized_urls = localized_urls.uniq - locs
+fail!("sitemap.xml is missing localized URLs: #{missing_localized_urls.join(", ")}") unless missing_localized_urls.empty?
+
 missing_lastmod = entries.select { |entry| entry["loc"].to_s.empty? || entry["lastmod"].to_s.empty? }.map { |entry| entry["loc"] }
 fail!("sitemap.xml entries are missing lastmod: #{missing_lastmod.join(", ")}") unless missing_lastmod.empty?
 
@@ -170,10 +193,35 @@ locs.each do |loc|
   fail!("#{loc} emits noindex") if noindex?(page.body)
 end
 
+localized_page_pairs.each do |pair|
+  variants = {
+    "en" => absolute_url(base_url, pair.fetch("en")),
+    "es" => absolute_url(base_url, pair.fetch("es"))
+  }
+
+  variants.each do |lang, url|
+    page = fetch(url, options)
+    assert_200!(page, url)
+
+    expected_html_lang = lang == "es" ? "es" : "en-us"
+    fail!("#{url} has html lang #{html_lang(page.body).inspect}, expected #{expected_html_lang.inspect}") unless html_lang(page.body) == expected_html_lang
+
+    links = hreflang_links(page.body)
+    variants.each do |alternate_lang, alternate_url|
+      next if links[alternate_lang] == alternate_url
+
+      fail!("#{url} is missing hreflang #{alternate_lang} => #{alternate_url}")
+    end
+
+    fail!("#{url} is missing hreflang x-default => #{variants.fetch("en")}") unless links["x-default"] == variants.fetch("en")
+  end
+end
+
 mode = options[:site_dir] ? "local build #{options[:site_dir]}" : "HTTP"
 puts "SEO crawl check passed for #{base_url} using #{mode}"
 puts "- homepage: 200"
 puts "- robots.txt: 200, allows crawling, points to #{absolute_url(base_url, "/sitemap.xml")}"
 puts "- sitemap.xml: 200 XML with #{locs.length} URLs and lastmod values"
 puts "- sitemap coverage: homepage and calculator pages present"
+puts "- localized pages: #{localized_page_pairs.length} English/Spanish hreflang pairs present"
 puts "- pages: #{locs.length} URLs returned 200, canonical matched, no noindex"


### PR DESCRIPTION
## Summary

- Add a Spanish SEO entry point at `/es/` plus three Spanish calculator pages.
- Add English/Spanish `hreflang` pairs, Spanish sitemap URLs, localized `html lang`, and Spanish navigation/footer copy.
- Localize calculator labels and CTA copy for Spanish pages while keeping existing calculator formulas and app store CTAs.
- Extend the SEO crawl script to validate localized sitemap coverage and reciprocal `hreflang` links.

Closes #17

## Verification

- `bundle exec jekyll build --quiet`
- `ruby scripts/check_seo_crawl.rb --site-dir _site`
- `node tests/calculator-formulas.test.js`
- `node --check` for `assets/js/analytics.js` and calculator scripts
- Generated HTML assertion for `/es/` and the three Spanish calculator pages: `html lang="es"`, `hreflang` links, and PDF copy present
- `git diff --check`

## Rendered QA

The in-app browser blocked direct `file://` access to the generated `_site` pages, and I did not start a local dev server because this frontend repo should not run dev/serve commands unless explicitly requested. Verification used the generated Jekyll output and HTML assertions instead.
