### PR TITLE
Redesign landing page and add import Universal Links

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,13 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "RLG6KSNL2Y.app.rehabestimator",
+        "paths": [
+          "/import/*"
+        ]
+      }
+    ]
+  }
+}

--- a/_config.yml
+++ b/_config.yml
@@ -175,6 +175,9 @@ sass:
   style: :compressed # You might prefer to minify using :compressed
 
 # Exclude these files from your production _site
+include:
+  - .well-known
+
 exclude:
   - LICENSE
   - README.md

--- a/tests/associated-links.test.rb
+++ b/tests/associated-links.test.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require "json"
+
+site_dir = File.expand_path("../_site", __dir__)
+aasa_path = File.join(site_dir, ".well-known", "apple-app-site-association")
+
+abort("Build the site before running this test: bundle exec jekyll build --quiet") unless Dir.exist?(site_dir)
+abort("Missing #{aasa_path}") unless File.file?(aasa_path)
+
+aasa = JSON.parse(File.read(aasa_path))
+details = aasa.fetch("applinks").fetch("details")
+app = details.find { |entry| entry["appID"] == "RLG6KSNL2Y.app.rehabestimator" }
+
+abort("Missing Universal Links appID") unless app
+abort("Missing /import/* Universal Links path") unless app.fetch("paths").include?("/import/*")
+
+puts "associated links test passed"


### PR DESCRIPTION
## Summary
- Redesign the landing page presentation and product workflow sections.
- Include `.well-known` in the Jekyll build output.
- Add the iOS `apple-app-site-association` file for `/import/*` so QR import links can open Rehab Estimator via Universal Links.

## Testing
- `bundle exec jekyll build --quiet`
- `ruby tests/associated-links.test.rb`
- `ruby tests/landing-homepage.test.rb`
- `node tests/calculator-formulas.test.js`
- `ruby scripts/check_seo_crawl.rb --site-dir _site`
- `git diff --check -- _config.yml .well-known/apple-app-site-association tests/associated-links.test.rb`

## Notes
- Android App Links still need `assetlinks.json` with the production signing certificate SHA-256 fingerprint before Android system camera scans can open the app directly.
