### PR TITLE
fix: include hidden files in Pages artifact

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./_site
+          include-hidden-files: true
 
   deploy:
     if: github.event_name != 'pull_request'

--- a/tests/associated-links.test.rb
+++ b/tests/associated-links.test.rb
@@ -4,6 +4,7 @@ require "json"
 
 site_dir = File.expand_path("../_site", __dir__)
 aasa_path = File.join(site_dir, ".well-known", "apple-app-site-association")
+workflow_path = File.expand_path("../.github/workflows/pages.yml", __dir__)
 
 abort("Build the site before running this test: bundle exec jekyll build --quiet") unless Dir.exist?(site_dir)
 abort("Missing #{aasa_path}") unless File.file?(aasa_path)
@@ -14,5 +15,8 @@ app = details.find { |entry| entry["appID"] == "RLG6KSNL2Y.app.rehabestimator" }
 
 abort("Missing Universal Links appID") unless app
 abort("Missing /import/* Universal Links path") unless app.fetch("paths").include?("/import/*")
+
+workflow = File.read(workflow_path)
+abort("Pages artifact must include hidden files") unless workflow.include?("include-hidden-files: true")
 
 puts "associated links test passed"


### PR DESCRIPTION
## Summary
- Enable hidden file uploads in the GitHub Pages artifact so `.well-known/apple-app-site-association` is deployed.
- Extend the associated links test to assert that the Pages artifact workflow includes hidden files.

## Testing
- `bundle exec jekyll build --quiet`
- `ruby tests/associated-links.test.rb`
- `ruby tests/landing-homepage.test.rb`
- `node tests/calculator-formulas.test.js`
- `ruby scripts/check_seo_crawl.rb --site-dir _site`
- `git diff --check -- .github/workflows/pages.yml tests/associated-links.test.rb`

## Notes
- This fixes the deployment gap from PR #21 where `_site/.well-known/apple-app-site-association` was built locally but excluded from the deployed Pages artifact.
