### PR TITLE
fix: add import link App Store fallback

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,75 @@
+---
+layout: page
+title: Page not found
+seo_title: Rehab Estimator import link
+meta_description: Open a shared Rehab Estimator import link in the app or download Rehab Estimator from the App Store.
+robots: noindex, follow
+permalink: /404.html
+---
+
+<section id="generic-not-found" class="not-found-section">
+  <p class="section-label">404</p>
+  <h1>Page not found</h1>
+  <p>The page you requested does not exist. Return to the Rehab Estimator homepage to continue.</p>
+  <div class="fallback-actions">
+    <a class="fallback-button fallback-button-primary" href="{{ '/' | relative_url }}">Go to homepage</a>
+  </div>
+</section>
+
+<section
+  id="import-link-fallback"
+  class="not-found-section import-link-fallback"
+  data-import-path-prefix="/import/"
+  hidden
+>
+  <p class="section-label">Shared estimate</p>
+  <h1>Open this import link in Rehab Estimator</h1>
+  <p>This QR code opens a calculator or report shared from Rehab Estimator.</p>
+  <div class="fallback-actions">
+    <a
+      id="import-open-link"
+      class="fallback-button fallback-button-primary"
+      href="{{ '/' | relative_url }}"
+      data-analytics-event="import_link_open_app"
+      data-cta-location="import_fallback"
+    >Open in Rehab Estimator</a>
+    <a
+      class="fallback-button"
+      href="{{ site.appstore_link }}"
+      data-analytics-event="app_store_cta_click"
+      data-store="app_store"
+      data-cta-location="import_fallback"
+    >Download on the App Store</a>
+  </div>
+  <p class="fallback-note">Install Rehab Estimator, then reopen this link or scan the QR again.</p>
+</section>
+
+<script>
+  (function () {
+    var importPanel = document.getElementById('import-link-fallback');
+    var genericPanel = document.getElementById('generic-not-found');
+    if (!importPanel || !genericPanel) {
+      return;
+    }
+
+    var prefix = importPanel.getAttribute('data-import-path-prefix');
+    var path = window.location.pathname;
+    if (!prefix || !path.startsWith(prefix) || path.length <= prefix.length) {
+      return;
+    }
+
+    var currentUrl = window.location.href;
+    var openLink = document.getElementById('import-open-link');
+    var smartBanner = document.querySelector('meta[name="apple-itunes-app"]');
+
+    genericPanel.hidden = true;
+    importPanel.hidden = false;
+
+    if (openLink) {
+      openLink.href = currentUrl;
+    }
+    if (smartBanner) {
+      smartBanner.setAttribute('content', "app-id={{ site.ios_app_id }}, app-argument=" + currentUrl);
+    }
+  })();
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
   {% assign resolved_description = page.meta_description | default: site.app_description %}
   {% assign resolved_url = page.url | absolute_url %}
   {% assign resolved_image = '/assets/product/report-builder-ipad.png' | absolute_url %}
+  {% assign robots_content = page.robots | default: "index, follow, max-image-preview:large" %}
   {% assign localized_en = "" %}
   {% assign localized_es = "" %}
   {% for localized_pair in site.localized_page_pairs %}
@@ -21,7 +22,7 @@
 
   <title>{{ resolved_title }}</title>
   <meta name="description" content="{{ resolved_description }}" />
-  <meta name="robots" content="index, follow, max-image-preview:large" />
+  <meta name="robots" content="{{ robots_content }}" />
   <link rel="canonical" href="{{ resolved_url }}" />
   {% if localized_en != "" and localized_es != "" %}
   <link rel="alternate" hreflang="en" href="{{ localized_en | absolute_url }}" />

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -730,6 +730,73 @@ main {
   margin-top: 22px;
 }
 
+.not-found-section {
+  display: grid;
+  gap: 18px;
+}
+
+.not-found-section[hidden] {
+  display: none;
+}
+
+.not-found-section h1 {
+  max-width: 680px;
+  color: $primary-text-color;
+  font-size: 4.4rem;
+  line-height: 1.05;
+}
+
+.not-found-section p:not(.section-label) {
+  max-width: 620px;
+  color: $muted-text-color;
+  font-size: 1.9rem;
+  line-height: 1.45;
+}
+
+.fallback-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.fallback-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 10px 16px;
+  border: 1px solid $soft-border-color;
+  border-radius: 8px;
+  color: $primary-text-color;
+  font-weight: 800;
+  text-decoration: none;
+  background: $paper-color;
+}
+
+.fallback-button:hover,
+.fallback-button:focus-visible {
+  border-color: $accent-color;
+  color: $accent-color;
+}
+
+.fallback-button-primary {
+  border-color: $accent-color;
+  color: #ffffff;
+  background: $accent-color;
+}
+
+.fallback-button-primary:hover,
+.fallback-button-primary:focus-visible {
+  color: #ffffff;
+  background: darken($accent-color, 6%);
+}
+
+.fallback-note {
+  padding-top: 8px;
+  font-weight: 700;
+}
+
 .related-calculators,
 .faq-section {
   margin-top: 34px;

--- a/tests/import-fallback.test.rb
+++ b/tests/import-fallback.test.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+site_dir = File.expand_path("../_site", __dir__)
+fallback_path = File.join(site_dir, "404.html")
+
+abort("Build the site before running this test: bundle exec jekyll build --quiet") unless Dir.exist?(site_dir)
+abort("Missing #{fallback_path}") unless File.file?(fallback_path)
+
+fallback = File.read(fallback_path)
+
+def assert_includes_html(html, expected)
+  abort("Expected import fallback to include #{expected.inspect}") unless html.include?(expected)
+end
+
+assert_includes_html(fallback, "<meta name=\"robots\" content=\"noindex, follow\"")
+assert_includes_html(fallback, "id=\"import-link-fallback\"")
+assert_includes_html(fallback, "data-import-path-prefix=\"/import/\"")
+assert_includes_html(fallback, "https://apps.apple.com/us/app/rehab-estimator/id1569047553")
+assert_includes_html(fallback, "Install Rehab Estimator, then reopen this link or scan the QR again.")
+assert_includes_html(fallback, "app-argument=\" + currentUrl")
+assert_includes_html(fallback, "id=\"import-open-link\"")
+
+puts "import fallback test passed"


### PR DESCRIPTION
## Summary
- Add a custom `404.html` that detects `/import/{token}` paths and shows an import-link fallback instead of the generic GitHub Pages 404.
- Add App Store and open-in-app CTAs, plus copy telling users to reopen the same link or rescan the QR after installing.
- Allow pages to override the robots meta tag and set the fallback page to `noindex, follow`.
- Add a regression test for the generated import fallback page.

Fixes #23

## Testing
- `bundle exec jekyll build --quiet`
- `ruby tests/import-fallback.test.rb`
- `ruby tests/associated-links.test.rb`
- `ruby tests/landing-homepage.test.rb`
- `node tests/calculator-formulas.test.js`
- `ruby scripts/check_seo_crawl.rb --site-dir _site`
- `git diff --check`

## Notes
- This static fallback can guide users to install the app and reopen the link. Automatic deferred import after App Store install remains out of scope for this change.
