### PR TITLE
fix: add Play Store fallback for import links

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 layout: page
 title: Page not found
 seo_title: Rehab Estimator import link
-meta_description: Open a shared Rehab Estimator import link in the app or download Rehab Estimator from the App Store.
+meta_description: Open a shared Rehab Estimator import link in the app or download Rehab Estimator from the App Store or Google Play.
 robots: noindex, follow
 permalink: /404.html
 ---
@@ -34,12 +34,21 @@ permalink: /404.html
       data-cta-location="import_fallback"
     >Open in Rehab Estimator</a>
     <a
+      id="import-app-store-link"
       class="fallback-button"
       href="{{ site.appstore_link }}"
       data-analytics-event="app_store_cta_click"
       data-store="app_store"
       data-cta-location="import_fallback"
     >Download on the App Store</a>
+    <a
+      id="import-play-store-link"
+      class="fallback-button"
+      href="{{ site.playstore_link }}"
+      data-analytics-event="play_store_cta_click"
+      data-store="play_store"
+      data-cta-location="import_fallback"
+    >Get it on Google Play</a>
   </div>
   <p class="fallback-note">Install Rehab Estimator, then reopen this link or scan the QR again.</p>
 </section>
@@ -60,7 +69,12 @@ permalink: /404.html
 
     var currentUrl = window.location.href;
     var openLink = document.getElementById('import-open-link');
+    var appStoreLink = document.getElementById('import-app-store-link');
+    var playStoreLink = document.getElementById('import-play-store-link');
     var smartBanner = document.querySelector('meta[name="apple-itunes-app"]');
+    var userAgent = window.navigator.userAgent || '';
+    var isAndroid = /Android/i.test(userAgent);
+    var isAppleMobile = /iPhone|iPad|iPod/i.test(userAgent);
 
     genericPanel.hidden = true;
     importPanel.hidden = false;
@@ -70,6 +84,10 @@ permalink: /404.html
     }
     if (smartBanner) {
       smartBanner.setAttribute('content', "app-id={{ site.ios_app_id }}, app-argument=" + currentUrl);
+    }
+    if (appStoreLink && playStoreLink) {
+      appStoreLink.hidden = isAndroid;
+      playStoreLink.hidden = isAppleMobile;
     }
   })();
 </script>

--- a/tests/import-fallback.test.rb
+++ b/tests/import-fallback.test.rb
@@ -17,8 +17,15 @@ assert_includes_html(fallback, "<meta name=\"robots\" content=\"noindex, follow\
 assert_includes_html(fallback, "id=\"import-link-fallback\"")
 assert_includes_html(fallback, "data-import-path-prefix=\"/import/\"")
 assert_includes_html(fallback, "https://apps.apple.com/us/app/rehab-estimator/id1569047553")
+assert_includes_html(fallback, "https://play.google.com/store/apps/details?id=app.estimator.rehab")
 assert_includes_html(fallback, "Install Rehab Estimator, then reopen this link or scan the QR again.")
 assert_includes_html(fallback, "app-argument=\" + currentUrl")
 assert_includes_html(fallback, "id=\"import-open-link\"")
+assert_includes_html(fallback, "id=\"import-app-store-link\"")
+assert_includes_html(fallback, "id=\"import-play-store-link\"")
+assert_includes_html(fallback, "var isAndroid = /Android/i.test(userAgent);")
+assert_includes_html(fallback, "var isAppleMobile = /iPhone|iPad|iPod/i.test(userAgent);")
+assert_includes_html(fallback, "appStoreLink.hidden = isAndroid;")
+assert_includes_html(fallback, "playStoreLink.hidden = isAppleMobile;")
 
 puts "import fallback test passed"


### PR DESCRIPTION
## Summary
- Add a Google Play CTA to the `/import/*` fallback page for users who scan QR links without the Android app installed.
- Hide the App Store CTA on Android and hide the Play Store CTA on iOS while keeping both visible on desktop or unknown platforms.
- Extend the import fallback test to verify the Play Store link and platform-specific CTA behavior.

## Testing
- `bundle exec jekyll build --quiet`
- `ruby tests/import-fallback.test.rb`
- `ruby tests/associated-links.test.rb`
- `git diff --check`
